### PR TITLE
Instead of raising an error, handle invalid area_units

### DIFF
--- a/lib/propertyware/models/building.rb
+++ b/lib/propertyware/models/building.rb
@@ -558,7 +558,8 @@ module Propertyware
     def area_units=(area_units)
       validator = EnumAttributeValidator.new('String', ["Sq Ft", "Sq M"])
       unless validator.valid?(area_units)
-        fail ArgumentError, "invalid value #{ area_units.inspect } for \"area_units\", must be one of #{validator.allowable_values}."
+        # fail ArgumentError, "invalid value #{ area_units.inspect } for \"area_units\", must be one of #{validator.allowable_values}."
+        area_units = "Sq Ft"
       end
       @area_units = area_units
     end

--- a/lib/propertyware/models/unit.rb
+++ b/lib/propertyware/models/unit.rb
@@ -466,7 +466,8 @@ module Propertyware
     def area_units=(area_units)
       validator = EnumAttributeValidator.new('String', ["Sq Ft", "Sq M"])
       unless validator.valid?(area_units)
-        fail ArgumentError, "invalid value #{ area_units.inspect } for \"area_units\", must be one of #{validator.allowable_values}."
+        # fail ArgumentError, "invalid value #{ area_units.inspect } for \"area_units\", must be one of #{validator.allowable_values}."
+        area_units = "Sq Ft"
       end
       @area_units = area_units
     end


### PR DESCRIPTION
Invalid data from PW's API is possible, and it's causing Sweyer's integration to not finish syncing. See [Honeybadger error](https://app.honeybadger.io/projects/1431/faults/113319495/01JBHQQMKXH74RSKJRX3HGFZJP?q=propertyware)