### PR TITLE
v1.3.2: Handle new payment type and fix generator for 1.3.1 changes

### DIFF
--- a/.openapi-generator/templates/ruby-client/partial_model_generic.mustache
+++ b/.openapi-generator/templates/ruby-client/partial_model_generic.mustache
@@ -278,7 +278,12 @@
     def {{{name}}}=({{{name}}})
       validator = EnumAttributeValidator.new('{{{dataType}}}', [{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}])
       unless validator.valid?({{{name}}})
+        {{#defaultValue}}
+        {{{name}}} = {{{defaultValue}}}
+        {{/defaultValue}}
+        {{^defaultValue}}
         fail ArgumentError, "invalid value #{ {{{name}}}.inspect } for \"{{{name}}}\", must be one of #{validator.allowable_values}."
+        {{/defaultValue}}
       end
       @{{{name}}} = {{{name}}}
     end

--- a/CUSTOMIZATIONS.md
+++ b/CUSTOMIZATIONS.md
@@ -6,6 +6,14 @@ These customizations reside in the `.openapi-generator/templates/ruby-client` fo
 
 ## Changelog
 
+### v1.3.2
+- Added new `PAYMENT_TYPE_NA` payment type option that Propertyware has started sending us. This patch is applied in fix_json.rb
+- Added default value for area_units in the models. This patch is applied in fix_json.rb. This along with the updates to the template, ensure that we fail gracefully with invalid values for these keys. See below.
+
+### v1.3.1
+
+- Added handling of invalid area_units values in the models. Update done, at the time of this commit, at `./.openapi-generator/templates/ruby-client/partial_model_generic.mustache:L281`.
+
 ### v1.0.0
 
 - In case we receive an enum with an invalid value, we are adding the received value in the error message to make debugging (and further contacting Propertyware) easier. Update done, at the time of this commit, at `./.openapi-generator/templates/ruby-client/partial_model_generic.mustache:L281`.

--- a/DOCS.md
+++ b/DOCS.md
@@ -325,7 +325,7 @@ gem build propertyware.gemspec
 Then either install the gem locally:
 
 ```shell
-gem install ./propertyware-1.3.0.gem
+gem install ./propertyware-1.3.2.gem
 ```
 
 (for development, run `gem install --dev ./propertyware-1.3.1.gem` to install the development dependencies)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Use Ruby 3.1.2 as the base image
+FROM ruby:3.1.2-slim
+
+# Install build dependencies, Node.js, and Java
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    curl \
+    default-jre \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory
+WORKDIR /app
+
+# Copy only the files needed for bundle install
+COPY Gemfile Gemfile
+COPY propertyware.gemspec propertyware.gemspec
+
+# Create empty version.rb file with placeholder version
+RUN mkdir -p lib/propertyware && \
+    echo 'module Propertyware\n  VERSION = "0.0.0"\nend' > lib/propertyware/version.rb
+
+# Install dependencies
+RUN bundle install
+
+# Copy the rest of the application
+COPY . .
+
+# Set the default command
+CMD ["bundle", "install"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    propertyware (1.3.1)
+    propertyware (1.3.2)
       faraday (>= 1.0.1, < 3.0)
       faraday-multipart
 

--- a/bin/CUSTOMIZATIONS.md
+++ b/bin/CUSTOMIZATIONS.md
@@ -6,9 +6,13 @@ These customizations reside in the `.openapi-generator/templates/ruby-client` fo
 
 ## Changelog
 
+### v1.3.2
+- Added new `PAYMENT_TYPE_NA` payment type option that Propertyware has started sending us. This patch is applied in fix_json.rb
+- Added default value for area_units in the models. This patch is applied in fix_json.rb. This along with the updates to the template, ensure that we fail gracefully with invalid values for these keys. See below.
+
 ### v1.3.1
 
-- Added handling of invalid area_units values in the models. Update done in [this commit](https://github.com/LeadSimple/propertyware/commit/9134454a3ec15862613f189a62fb867c5e16bee8). This will need to be applied manually if we regenerate the models. More ambitiously in the future, we could do a larger update to `./.openapi-generator/templates/ruby-client/partial_model_generic.mustache`, to warn instead of failing if we receive invalid values.
+- Added handling of invalid area_units values in the models. Update done, at the time of this commit, at `./.openapi-generator/templates/ruby-client/partial_model_generic.mustache:L281`.
 
 ### v1.0.0
 

--- a/bin/config.yml
+++ b/bin/config.yml
@@ -4,4 +4,4 @@ additionalProperties:
   gemHomepage: https://github.com/LeadSimple/propertyware
   gemDescription: API client library for Propertyware
   gemRequiredRubyVersion: "> 2.6.0"
-  gemVersion: 1.3.1
+  gemVersion: 1.3.2

--- a/bin/fix_json.rb
+++ b/bin/fix_json.rb
@@ -55,5 +55,20 @@ data['components']['securitySchemes'] = {
 # Guarantee we automatically set HTTPS as the schema
 data['servers'][0] = { "url": "https://api.propertyware.com/pw/api/rest/v1" } unless data['servers'].first['url'].start_with?("https://")
 
+data['components']['schemas'].each do |schema_name, schema|
+  next unless schema['properties']
+  
+  # Ensure all paymentType enums include PAYMENT_TYPE_NA
+  if schema['properties']['paymentType']&.dig('enum')
+    payment_types = schema['properties']['paymentType']['enum']
+    payment_types << 'PAYMENT_TYPE_NA' unless payment_types.include?('PAYMENT_TYPE_NA')
+  end
+
+  # make sure that every area_units key has a default value
+  if schema['properties']['areaUnits']
+    schema['properties']['areaUnits']['default'] = 'Sq Ft'
+  end
+end
+
 # Save it back to the file
-File.write('bin/propertyware.json', data.to_json)
+File.write('bin/propertyware.json', JSON.pretty_generate(data))

--- a/bin/propertyware.json
+++ b/bin/propertyware.json
@@ -4,7 +4,10 @@
     "description": "﻿<script type=\"text/javascript\" src=\"https://buildium.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/-raa8on/b/8/c95134bc67d3a521bb3f4331beb9b804/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=e43cd15d\"></script>\r\n\r\n# Introduction\r\n\r\nWelcome to Propertyware’s API—a powerful, RESTful programming interface that lets you leverage valuable Propertyware data.\r\n\r\n## Account Configuration\r\nBefore you can use Propertyware’s API, you’ll need to make some tweaks to your account settings. \r\n\r\n<br />\r\n\r\n### Enabling the API \r\nIn order to start creating your keys and making requests, you’ll need to enable the API.\r\n\r\n>  **Tip:** You’ll need an administrator user role with access to ***Administration Setup > API Keys*** to set things up properly. \r\n\r\n**Let's Begin!** \r\n\r\n1. Sign in to your [Propertyware](https://app.propertyware.com/pw/login.jsp) account from your browser. \r\n\r\n2. Open the ***Setup*** page\r\n\r\n3. On the left navigation bar, expand ***Administration Setup*** and then click ***API Keys***. \r\n\r\nIf you are having issues accessing the API keys page within your account you can submit a [Support](#section/API-Overview/Support) request for assistance.\r\n\r\n## API Keys\r\nAccount-level API keys authenticate every request and keep things secure. \r\n\r\nAPI keys have two components: a “client ID” and a “secret”.\r\n\r\n* **Client IDs** are similar to usernames. They’re used to identify your Propertyware API key and are safe to share.\r\n* **Secrets** are similar to passwords. They must be kept confidential. \r\n\r\nWhenever you make a request, you’ll need the API key’s client ID and secret. If you forget it, make a mistake, or try to use information that’s linked to a deleted key, the API will return a `401` response code.\r\n\r\n>  **Tip:** We compiled a list of best practices that detail how securely store API keys. [Give it a read](#section/Getting-Started/Keeping-API-Keys-Safe)!\r\n\r\n## Creating API Keys \r\n\r\nNow that the Open API is enabled, you’ll be able to create API keys. You’re almost there!\r\n\r\n**How to create an API key** \r\n\r\n1. On the API Keys page, click ***Create API Key***. A modal will appear.\r\n\r\n<p>\r\n    <img src=\"APIKey_Page.JPG\"/>\r\n</p>\r\n\r\n<p>\r\n    <img src=\"APIKey_New.JPG\"/>\r\n</p>\r\n\r\n2. Enter a clear, memorable name and description for your API key. It’ll make it easier to locate the right key when you make a request.\r\n\r\n3. Now, choose which pieces of Propertyware data you want this API key to have access to by selecting the corresponding radio buttons. Once finished, click **GENERATE KEY**.\r\n\r\n4. You have successfully created an API key! The client id and secret associated to this key will be presented. \r\n\r\n<p>\r\n    <img src=\"APIKey_Generate.JPG\"/>\r\n</p>\r\n\r\n> **Important:** This is your only chance to record the secret. Make sure it’s stored somewhere secure! If it’s forgotten, you’ll need to delete this key and start from scratch.\r\n\r\n\r\nYou have now successfully created an API key and have everything you need to  send requests to the Propertyware API! \r\n\r\nBefore moving on to [making your first request](#section/Getting-Started/How-to-Make-a-Request) please review [Keeping API Keys Safe](#section/Getting-Started/Keeping-API-Keys-Safe) for an overview on securely storing your API keys.  \r\n<br />\r\nIf you are having issues creating API keys you can submit a [Support](#section/API-Overview/Support) request for assistance.\r\n\r\n## Keeping API Keys Safe\r\n\r\nBased on their permissions, API keys could have full access to your account’s Propertyware data. It’s important that you only grant access to trusted applications, securely record secrets, and consider a password manager to stay organized.\r\n\r\n### Recommended Practices\r\n\r\n- Avoid hard-coding client IDs and secrets inside source files.\r\n- Avoid storing client IDs and secrets in any files that may be committed to source control, particularly cloud-based source control platforms.\r\n- Apply restrictions to client IDs and secrets shared with your staff. You can restrict a key to particular Propertyware entities or to read-only access (GET resources only).\r\n- Avoid sharing client IDs and secrets across public, insecure platforms.\r\n- Establish a process to regularly recreate your client IDs and secrets from your Propertyware account.\r\n<br />\r\n<br />\r\n\r\n## How to Make a Request \r\n\r\nYou’ve done a great job setting up your account, Now, we’ll walk you through how to access your data. It’s very straightforward and should only take a few minutes!\r\n\r\n> **Tip:** Looking for the right HTTP client? If you’re just getting started, we recommend Postman. \r\n\r\n### Let's Get Started!\r\n\r\n#### Step 1: Get Your API Key\r\n\r\nIf you haven't yet done so, obtain your API key client ID and secret from your Propertyware account. Your API key is how the Propertyware API authenticates requests and ensures only you can access your data.\r\n\r\n#### Step 2: Install a HTTP client\r\n\r\nThe Propertyware API supports any standard HTTP client. If you're looking for a user-friendly HTTP client application, we recommend [Postman](https://www.postman.com/product/api-client) – it allows you to access the Propertyware API without writing code. We’ll use Postman for our example below to demonstrate sending an API request.\r\n\r\n#### Step 3: Make a Sample Request\r\n\r\nLet's dive in and make a simple request to get all the [Buildings](#operation/getBuildingsUsingGET) in your account. This will confirm your connectivity to our platform and validate the keys you created on our website. Simply follow the instructions below.\r\n\r\n1. Open the Postman application. \r\n2. Open the *verb* menu and select **GET**.\r\n3. Enter the request endpoint in the field next to GET. \r\n   - Here’s the endpoint to get all buildings: https://api.propertyware.com/pw/api/rest/v1/buildings.\r\n4. To authenticate the request, enter your `client ID`, your `secret` and your `organization iD` respectively in these request headers: \r\n   - `x-propertyware-client-id`\r\n   - `x-propertyware-client-secret`\r\n   - `x-propertyware-system-id` _(organization id)_\r\n\r\nThe organization id uniquely identifies your Propertyware account and is an additional measure to enforce proper access to the correct data. ___Your client id and secret pair will only work with the organization it belongs to___.\r\n\r\nYour full request should look similar to the image below.\r\n<kbd><img src=\"request_example.png\" /></kbd>\r\n\r\n5. Review the parameters of your request on last time. Once finished, click **Send**.\r\n\r\n6. If successful, you should see a JSON response and a `200` HTTP status code. Congratulations! You've connected to the Propertyware API.\r\n\r\nYou now have the knowledge required to make requests for any of our resources.\r\n\r\nIf you've received an error response please review the JSON response message for a description of how to resolve the issue. You can also see more information about HTTP status codes in the [Response Codes](#section/API-Overview/Response-Codes) section. If you are still having trouble making a request after reviewing these sections please submit a [Support](#section/API-Overview/Support) request.\r\n\r\n# API Overview\r\nThe Propertyware API is built upon standard REST conventions. It's designed to use consistent resource-oriented URLs, accept and return JSON-encoded messages, and use standard HTTP status codes and verbs.\r\n\r\n## Base URL\r\nThe base URL for production environment API requests is: `https://api.propertyware.com/pw/api/v1/rest`\r\n\r\nIn order to ensure all requests and responses are secure between the API consumer and Propertyware servers, requests must be made using the `https` protocol. Any requests not made with the `https` protocol will be refused by the Propertyware API platform. \r\n\r\n> **Note:** URL paths are case-sensitive to stay consistent with common REST standards. If your request doesn’t align with the documented URL path, you’ll receive a `404` response code reminding you of this constraint.\r\n\r\n## API Versioning\r\nThe Propertyware API is version controlled. Versioning ensures backwards-incompatible changes to the API don’t impact any existing integrations.\r\n\r\nPropertyware uses only a major version nomenclature to manage changes. The current version of the Propertyware API is version 1. By specifying a version in the resource request URL, you'll get expected responses regardless of future changes to the API. Here's an example of calling version 1 of the retrieve all leases resource:\r\n\r\n`https://api.propertyware.com/pw/api/rest/v1/leases`\r\n\r\nAny request submitted without the version in the URL path will result in a `404` error response code. \r\n\r\n### Releasing Changes to the API\r\nThe Propertyware API will continue to evolve to ensure it meets the needs of our customers. Changes will be defined as either backwards-compatible or backwards-incompatible. \r\n\r\nWe’ll provide advance notice for all API releases–regardless of the type of modifications being made. \r\n\r\n#### Backward-compatible Changes\r\nBackward-compatible changes are modifications to the API that shouldn't impact existing integrations. They'll apply to the current version of the API. Simply put: you won’t need to change the version to consume new changes like these. \r\n\r\nIt's important as you develop against the Propertyware API that you ensure  these types of changes don't impact your integration. Here's are examples of backward-compatible modifications. \r\n\r\n* Adding new API resources and/or endpoints.\r\n* Adding new optional request parameters to existing API methods.\r\n* Adding new properties to existing API responses and non-required properties for request messages.\r\n* Changing property order in existing API responses.\r\n\r\nAll backward-compatible changes to the API will be documented in the [Changelog](#section/Changelog).\r\n\r\n#### Backwards-incompatible Changes\r\n\r\nWhen backwards-incompatible changes to the API occur, a new version of the API will be released. You’ll need to update the URL path  to consume resources under the new API version. \r\n\r\nBackwards-incompatible changes include:\r\n\r\n* Removing a property from a request and/or response message.\r\n* Changing the name of a property in a message.\r\n* Adding a required parameter to a request message.\r\n* Changing existing enumeration values.\r\n\r\nNew versions of the API will have full reference documentation and an upgrade guide. \r\n\r\n## Authentication\r\n\r\nThe Propertyware API uses API key’s client IDs and secrets to authenticate requests. \r\n\r\nAn organization ID, an API key client ID and secret must be passed in every request header using the following parameters: \r\n\r\n- `x-propertyware-client-id`\r\n- `x-propertyware-client-secret`\r\n- `x-propertyware-system-id`\r\n\r\nFailing to provide both of them in the request header will cause the API to return a `401` HTTP status code.\r\n<!--\r\n## Rate Limiting (FUTURE)\r\nRate limits help us ensure consistent and reliable performance for all users, even during peak loads. That’s why we limit clients to **10 concurrent requests per second**.\r\n\r\nIf your request rate violates that limit, a response code of `429` is returned. Simply retry the request after a short interval (~200ms).\r\n-->\r\n\r\n## Bulk Request Options\r\nAll top-level API resources support bulk fetches. For instance, you can retrieve all [Portfolios](#operation/getPortfoliosUsingGET). These resources also allow for filtering criteria. Each resource has descriptions of the filter criteria available.\r\n\r\nIn addition to filtering, our API gives you the ability to control the returned data’s pagination and the sort order. \r\n\r\n### Pagination\r\nEndpoints that return result sets allow for pagination using `limit` and `offset` request parameters to reduce the amount of data returned.\r\n\r\nThe `limit` request parameter will cap the number of results that come back in the response. If you don't specify a `limit` value, a **default of 100 results** are returned. The maximum `limit` value is 500. If a `limit` value is specified greater than 500, it will be overridden to the default to 500. \r\n\r\nThe `offset` request parameter indicates the record position within the resultset to start at when returning the results. The `offset` is zero-based and is inclusive. If no `offset` value is submitted it will default to 0. \r\n\r\n\r\nThe total resultset count is returned in the HTTP Header `X-Total-Count`\r\n\r\n\r\n#### Pagination Example\r\n\r\nAs an example, let's say we make a request to retrieve all rental properties with no paging parameters. Our response indicates in the `X-Total-Count` header that there are 150 total rental properties. We want to get only the last 50 results so we would submit a request with the `offset` set to 100 and the `limit` set to 50.\r\n\r\n> **Note:** The `limit` and `offset` parameter names are case-sensitive. If they aren't formatted correctly, the API will return a `404` HTTP status code.\r\n\r\n### Sorting Results\r\n\r\nYou can specify the sort order of returned data by assigning properties from the returned object to the `orderby` parameter in the querystring. For example:\r\n```\r\norderby=name\r\n```\r\nBy default, the sort is performed in ascending order. To specify sort order, use \"asc\" for ascending or \"desc\" for descending. For example:\r\n```\r\norderby=name desc\r\n```\r\nAdditionally, you can sort by multiple properties by comma separating the properties. For example:\r\n```\r\norderby=abbreviation asc,name desc\r\n```\r\n\r\n> **Note:** While the `orderby` parameter is case-sensitive, the properties specified in the `orderby` value aren't. \r\n\r\n## Response Codes\r\nThe Propertyware API supports standard HTTP status codes.\r\n\r\n|Response Code          |Description  |\r\n|--|--|\r\n|200 OK | Everything worked as expected. |\r\n|400 Bad Request | The request was unacceptable, often due to missing a required parameter.|\r\n|401 Unauthorized|The API client ID and secret weren’t provided or they’re no longer valid. Be sure that the client ID and secret combination are correct and they are still active.|\r\n|403 Forbidden|The API key doesn't have permission to perform the request. This could be due to authorization for the given endpoint or an inability to access given entities within the platform (e.g. properties).\r\n|404 Not Found|The requested resource doesn't exist.|\r\n|415 Unsupported Media Type |Ensure you have the appropriate content-type header value set on your request. Each resource is documented with media type(s) that are accepted.|\r\n|429 Too Many Requests |Too many requests against the API too quickly. We recommend an exponential backoff of your requests.|\r\n|500 and above - Server Errors|Something went wrong on Propertyware's end. Review the JSON response message for more details about the error.|\r\n\r\n## API Date Format\r\n* For all request and response date fields allowing ISO date format: YYYY-MM-DD (e.g.2019-08-24).\r\n* For all request and response dateAndTime fields format is allowing: YYYY-MM-dd'T'HH:mm:ssXXX (e.g.2022-06-28T08:47:13Z).\r\n\r\n## Support\r\nIf you are unable to resolve your issue after reviewing the API documentation our support team can assist you.\r\n\r\n# Changelog\r\n### 2023-08-28\r\n* Update a document\r\n\r\n### 2023-07-11\r\n* Delete a document\r\n\r\n### 2023-07-11\r\n* Retrieve all documents\r\n* Retrieve a document\r\n* Download a document\r\n\r\n### 2023-06-10\r\n* Lease contacts are included in Retrieve all leases API response\r\n* Lease contacts are included in Retrieve a lease API response\r\n\r\n### 2023-04-24\r\n* Bulk Insertion: Prospects\r\n* Bulk Insertion: Bill Payments\r\n\r\n### 2023-04-11\r\n\r\n* Bulk Insertion: Portfolios\r\n* Bulk Insertion: Buildings\r\n* Bulk Insertion: Units\r\n\r\n### 2023-03-19\r\n\r\n* Bulk insertion: contacts\r\n\r\n### 2023-03-08\r\n\r\n* Bulk insertion: bills\r\n\r\n### 2023-01-24\r\n\r\n* Custom fields in \"Get all\" endpoints\r\n* Prospect creation\r\n* Bill removals \r\n \r\n### 2022-10-25\r\n\r\n* API Read operations for non-financial data\r\n\r\n### 2022-09-21\r\n\r\n* API Read operations available ",
     "version": "1.0",
     "title": "Open API, powered by Propertyware",
-    "contact": { "name": "Propertyware", "email": "support@propertyware.com" },
+    "contact": {
+      "name": "Propertyware",
+      "email": "support@propertyware.com"
+    },
     "x-logo": {
       "url": "logo.png",
       "backgroundColor": "#fff",
@@ -37,7 +40,10 @@
       "name": "Documents",
       "description": "Resources providing access to documents."
     },
-    { "name": "Health check", "description": "API health check resources." },
+    {
+      "name": "Health check",
+      "description": "API health check resources."
+    },
     {
       "name": "Inspections",
       "description": "Resources providing access to inspections."
@@ -54,7 +60,10 @@
       "name": "Prospects",
       "description": "Resources providing access to prospects."
     },
-    { "name": "Units", "description": "Resources providing access to units." },
+    {
+      "name": "Units",
+      "description": "Resources providing access to units."
+    },
     {
       "name": "Vendors",
       "description": "Resources providing access to vendors."
@@ -67,14 +76,18 @@
   "paths": {
     "/accounting/bankdeposits": {
       "post": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Create a bank deposit (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a bank deposit.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">GENERAL LEDGER</span> - <code>Write</code>\n",
         "operationId": "createBankDeposit",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SaveBankDeposit" }
+              "schema": {
+                "$ref": "#/components/schemas/SaveBankDeposit"
+              }
             }
           },
           "description": "saveBankDeposit",
@@ -85,7 +98,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BankDeposit" }
+                "schema": {
+                  "$ref": "#/components/schemas/BankDeposit"
+                }
               }
             }
           },
@@ -93,7 +108,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -101,7 +118,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -109,7 +128,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -118,7 +139,9 @@
     },
     "/accounting/bankdeposits/{bankDepositID}": {
       "delete": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Delete a Bank Deposit (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDelete a Bank Deposit.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">GENERAL LEDGER</span> - <code>Delete</code>\n",
         "operationId": "deleteBankDeposit",
@@ -128,7 +151,10 @@
             "in": "path",
             "description": "Bank Deposit ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -136,7 +162,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -144,7 +172,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -152,7 +182,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -160,17 +192,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/accounting/generalledger": {
       "get": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Retrieve all general ledger transactions (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves a list of general ledger transactions.<br /><br />At least of the following date ranges must be passed as a filter: \n * `lastModifiedDateStart`-`lastModifiedDateEnd` \n * `createdDateStart`-`createdDateEnd`<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">GENERAL LEDGER</span> - <code>Read</code>\n",
         "operationId": "getGeneralLedgerTransactions",
@@ -180,77 +218,110 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "leaseID",
             "in": "query",
             "description": "Filters results to transactions associated with a specific lease.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "ownerID",
             "in": "query",
             "description": "Filters results to transactions associated with a specific owner.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "vendorID",
             "in": "query",
             "description": "Filters results to transactions associated with a specific vendor.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results to transactions associated with a specific Portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "postDateStart",
             "in": "query",
             "description": "Filters results to any transaction with post date on or after to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "postDateEnd",
             "in": "query",
             "description": "Filters results to any transaction with post date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           }
         ],
         "responses": {
@@ -259,14 +330,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/GLItem" }
+                  "items": {
+                    "$ref": "#/components/schemas/GLItem"
+                  }
                 }
               }
             }
@@ -275,7 +351,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -283,7 +361,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -291,7 +371,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -300,7 +382,9 @@
     },
     "/accounting/glaccounts": {
       "get": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Retrieve all the general ledger accounts (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves a list of general ledger accounts.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">GL ACCOUNTS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>accountcode</code>, <code>id</code>, <code>accountnumber</code>",
         "operationId": "getAccounts",
@@ -310,63 +394,87 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "accountNumber",
             "in": "query",
             "description": "Filters results to accounts with a specific number.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "includeDeactivated",
             "in": "query",
             "description": "Include deactivated results if a `true` value is passed. If no value is specified, only active accounts will be returned.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "accountCode",
             "in": "query",
             "description": "Filters results to accounts with a specific code.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "parentGLAccountId",
             "in": "query",
             "description": "Filters results to accounts that are a children of a specific parent account.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -375,14 +483,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Account" }
+                  "items": {
+                    "$ref": "#/components/schemas/Account"
+                  }
                 }
               }
             }
@@ -391,7 +504,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -399,7 +514,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -407,24 +524,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Create a general ledger account (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreate a general ledger account.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">GL ACCOUNTS</span> - <code>Write</code>\n",
         "operationId": "createGLAccount",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveAccount" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveAccount"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Account" }
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
               }
             }
           },
@@ -432,7 +557,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -440,7 +567,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -448,7 +577,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -457,7 +588,9 @@
     },
     "/accounting/glaccounts/bulk": {
       "post": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Create general ledger accounts in bulk (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates general ledger accounts in bulk.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">GL ACCOUNTS</span> - <code>Write</code>\n",
         "operationId": "createBillPayments",
@@ -466,7 +599,9 @@
             "application/json": {
               "schema": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/SaveAccount" }
+                "items": {
+                  "$ref": "#/components/schemas/SaveAccount"
+                }
               }
             }
           },
@@ -504,7 +639,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -512,7 +649,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -521,7 +660,9 @@
     },
     "/accounting/glaccounts/{glAccountID}": {
       "put": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Update a general ledger account (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates a general ledger account.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">GL ACCOUNTS</span> - <code>Write</code>\n",
         "operationId": "updateGLAccount",
@@ -531,16 +672,23 @@
             "in": "path",
             "description": "GL Account ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveAccount" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveAccount"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Account" }
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
               }
             }
           },
@@ -548,7 +696,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -556,7 +706,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -564,17 +716,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/accounting/glaccounts/{glAccount}": {
       "delete": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Delete a general ledger account (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDelete a general ledger account.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">GL ACCOUNTS</span> - <code>Delete</code>\n",
         "operationId": "deleteGLAccount",
@@ -584,7 +742,10 @@
             "in": "path",
             "description": "GL Account ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -592,7 +753,9 @@
             "description": "No Content",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -600,7 +763,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -608,7 +773,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -616,17 +783,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/accounting/ownercontributions": {
       "get": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Retrieve all the owner contributions (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves a list of owner contributions.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>postdate</code>, <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getOwnerContributions",
@@ -636,70 +809,99 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "postDateStart",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "postDateEnd",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "leaseID",
             "in": "query",
             "description": "Filters results with Lease ID.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filters results to with Lease Status.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -708,14 +910,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/OwnerContribution" }
+                  "items": {
+                    "$ref": "#/components/schemas/OwnerContribution"
+                  }
                 }
               }
             }
@@ -724,7 +931,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -732,7 +941,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -740,21 +951,27 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Create an owner contribution (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates an owner contribution for a specified owner contact.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Write</code>\n",
         "operationId": "createOwnerContribution",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SaveOwnerContribution" }
+              "schema": {
+                "$ref": "#/components/schemas/SaveOwnerContribution"
+              }
             }
           },
           "description": "saveOwnerContribution",
@@ -765,7 +982,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/OwnerContribution" }
+                "schema": {
+                  "$ref": "#/components/schemas/OwnerContribution"
+                }
               }
             }
           },
@@ -773,7 +992,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -781,7 +1002,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -789,7 +1012,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -798,7 +1023,9 @@
     },
     "/accounting/ownercontributions/{ownerContributionID}": {
       "delete": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Delete Owner Contribution (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDelete Owner Contribution.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Delete</code>\n",
         "operationId": "deleteOwnerContribution",
@@ -808,7 +1035,10 @@
             "in": "path",
             "description": "Owner Contribution ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -816,7 +1046,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -824,7 +1056,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -832,7 +1066,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -840,17 +1076,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/accounting/ownerdraws": {
       "get": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Retrieve all the owner draws (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves a list of owner draws.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>postdate</code>, <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>portfolioid</code>, <code>id</code>",
         "operationId": "getOwnerDraws",
@@ -860,56 +1102,80 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "postDateStart",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "postDateEnd",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results to with portfolioID.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -918,14 +1184,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/OwnerDraw" }
+                  "items": {
+                    "$ref": "#/components/schemas/OwnerDraw"
+                  }
                 }
               }
             }
@@ -934,7 +1205,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -942,7 +1215,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -950,24 +1225,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Create an owner draw (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates an owner draw for a specified owner contact.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Write</code>\n",
         "operationId": "createOwnerDraw",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveOwnerDraw" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveOwnerDraw"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/OwnerDraw" }
+                "schema": {
+                  "$ref": "#/components/schemas/OwnerDraw"
+                }
               }
             }
           },
@@ -975,7 +1258,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -983,7 +1268,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -991,7 +1278,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -1000,7 +1289,9 @@
     },
     "/accounting/ownerdraws/{drawID}": {
       "put": {
-        "tags": ["Accounting"],
+        "tags": [
+          "Accounting"
+        ],
         "summary": "Update an owner draw (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates an owner draw for a specified owner contact.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Write</code>\n",
         "operationId": "updateOwnerDraw",
@@ -1010,16 +1301,23 @@
             "in": "path",
             "description": "Owner Draw ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveOwnerDraw" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveOwnerDraw"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/OwnerDraw" }
+                "schema": {
+                  "$ref": "#/components/schemas/OwnerDraw"
+                }
               }
             }
           },
@@ -1027,7 +1325,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1035,7 +1335,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1043,17 +1345,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/bills": {
       "get": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Retrieve all bills (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves a list of bills.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BILLS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>billdate</code>, <code>billnumber</code>, <code>lastmodifieddatetime</code>, <code>duedate</code>, <code>id</code>",
         "operationId": "getBills",
@@ -1063,98 +1371,139 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results to bills associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "vendorID",
             "in": "query",
             "description": "Filters results to bills associated with a specific vendor.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "workOrderID",
             "in": "query",
             "description": "Filters results to bills associated with a specific work order.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "markupGLAccountID",
             "in": "query",
             "description": "Filters results to bills associated with a specific markup general ledger account.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "paid",
             "in": "query",
             "description": "Filters results by the bill's paid status. If no status is specified, bills with any status will be returned.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "billDateStart",
             "in": "query",
             "description": "Filters results to any bill with a billing date on or after to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "billDateEnd",
             "in": "query",
             "description": "Filters results to any bill with a billing date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "dueDateStart",
             "in": "query",
             "description": "Filters results to any bill with a due date on or after to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "dueDateEnd",
             "in": "query",
             "description": "Filters results to any bill with a due date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           }
         ],
         "responses": {
@@ -1163,14 +1512,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Bill" }
+                  "items": {
+                    "$ref": "#/components/schemas/Bill"
+                  }
                 }
               }
             }
@@ -1179,7 +1533,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1187,7 +1543,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1195,24 +1553,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Create a bill (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a bill.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BILLS</span> - <code>Write</code>\n",
         "operationId": "createBill",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveBill" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveBill"
+        },
         "responses": {
           "201": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Bill" }
+                "schema": {
+                  "$ref": "#/components/schemas/Bill"
+                }
               }
             }
           },
@@ -1220,7 +1586,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1228,7 +1596,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1236,7 +1606,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -1245,7 +1617,9 @@
     },
     "/bills/bulk": {
       "post": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Create bills in bulk (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates bills in bulk.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BILLS</span> - <code>Write</code>\n",
         "operationId": "createBills",
@@ -1254,7 +1628,9 @@
             "application/json": {
               "schema": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/SaveBill" }
+                "items": {
+                  "$ref": "#/components/schemas/SaveBill"
+                }
               }
             }
           },
@@ -1292,7 +1668,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1300,7 +1678,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -1309,17 +1689,23 @@
     },
     "/bills/credit": {
       "post": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Create a credit (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a credit.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BILLS</span> - <code>Write</code>\n",
         "operationId": "createCredit",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveCredit" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveCredit"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Bill" }
+                "schema": {
+                  "$ref": "#/components/schemas/Bill"
+                }
               }
             }
           },
@@ -1327,7 +1713,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1335,7 +1723,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1343,7 +1733,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -1352,7 +1744,9 @@
     },
     "/bills/credit/{creditID}": {
       "put": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Update a Credit (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdate an existing Credit.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BILLS</span> - <code>Write</code>\n",
         "operationId": "updateCredit",
@@ -1362,16 +1756,23 @@
             "in": "path",
             "description": "Credit ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveCredit" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveCredit"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Bill" }
+                "schema": {
+                  "$ref": "#/components/schemas/Bill"
+                }
               }
             }
           },
@@ -1379,7 +1780,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1387,7 +1790,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1395,27 +1800,37 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/bills/payment": {
       "post": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Creates Bill Payment (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates Bill Payment<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Write</code>\n",
         "operationId": "createBillPayment",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveBillPayment" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveBillPayment"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BillPayment" }
+                "schema": {
+                  "$ref": "#/components/schemas/BillPayment"
+                }
               }
             }
           },
@@ -1423,7 +1838,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1431,7 +1848,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1439,7 +1858,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -1448,7 +1869,9 @@
     },
     "/bills/payment/{billPaymentID}": {
       "put": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Update a Bill Payment (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdate a Bill Payment<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Write</code>\n",
         "operationId": "updateBillPayment",
@@ -1458,16 +1881,23 @@
             "in": "path",
             "description": "Bill Payment ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveBillPayment" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveBillPayment"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BillPayment" }
+                "schema": {
+                  "$ref": "#/components/schemas/BillPayment"
+                }
               }
             }
           },
@@ -1475,7 +1905,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1483,7 +1915,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1491,7 +1925,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -1500,7 +1936,9 @@
     },
     "/bills/payments": {
       "get": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Retrieve all bill payments (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves a list of bill payments.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BILLS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>vendorid</code>, <code>lastmodifieddatetime</code>, <code>paymentdate</code>, <code>checknumber</code>, <code>id</code>",
         "operationId": "getBillPayments",
@@ -1510,63 +1948,90 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "vendorID",
             "in": "query",
             "description": "Filters results to bills associated with a specific vendor.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "paymentGLAccountID",
             "in": "query",
             "description": "Filters results to bills associated with a specific payment general ledger account.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "paymentDateStart",
             "in": "query",
             "description": "Filters results to any payment with a date on or after to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "paymentDateEnd",
             "in": "query",
             "description": "Filters results to any payment with a date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           }
         ],
         "responses": {
@@ -1575,14 +2040,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/BillPayment" }
+                  "items": {
+                    "$ref": "#/components/schemas/BillPayment"
+                  }
                 }
               }
             }
@@ -1591,7 +2061,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1599,7 +2071,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1607,7 +2081,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -1616,7 +2092,9 @@
     },
     "/bills/payments/bulk": {
       "post": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Create bill payments in bulk (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates bill payments in bulk.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Write</code>\n",
         "operationId": "createBillPaymentsUsingPOST_1",
@@ -1625,7 +2103,9 @@
             "application/json": {
               "schema": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/SaveBillPayment" }
+                "items": {
+                  "$ref": "#/components/schemas/SaveBillPayment"
+                }
               }
             }
           },
@@ -1663,7 +2143,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1671,7 +2153,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -1680,7 +2164,9 @@
     },
     "/bills/payments/{billPaymentID}": {
       "get": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Retrieve a bill payment (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves a specific bill payment.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BILLS</span> - <code>Read</code>\n",
         "operationId": "getBillPayment",
@@ -1690,7 +2176,10 @@
             "in": "path",
             "description": "Bill Payment ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -1698,7 +2187,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/BillPayment" }
+                "schema": {
+                  "$ref": "#/components/schemas/BillPayment"
+                }
               }
             }
           },
@@ -1706,7 +2197,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1714,7 +2207,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1722,17 +2217,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/bills/vendorChecks": {
       "get": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Retrieve all Vendor checks (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves a list of Vendor checks.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>postdate</code>, <code>createddate</code>, <code>vendorid</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getVendorChecks",
@@ -1742,63 +2243,90 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "postDateStart",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "postDateEnd",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "vendorID",
             "in": "query",
             "description": "Filters results to transactions associated with a specific vendor.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -1807,14 +2335,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Check" }
+                  "items": {
+                    "$ref": "#/components/schemas/Check"
+                  }
                 }
               }
             }
@@ -1823,7 +2356,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1831,7 +2366,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1839,24 +2376,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Create a Vendor check (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a Vendor check.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Write</code>\n",
         "operationId": "createVendorCheck",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveCheck" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveCheck"
+        },
         "responses": {
           "201": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Check" }
+                "schema": {
+                  "$ref": "#/components/schemas/Check"
+                }
               }
             }
           },
@@ -1864,7 +2409,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1872,7 +2419,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1880,7 +2429,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -1889,7 +2440,9 @@
     },
     "/bills/vendorChecks/{vendorCheckID}": {
       "put": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Update a Vendor check (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdate an existing Vendor check.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Write</code>\n",
         "operationId": "updateVendorCheck",
@@ -1899,16 +2452,23 @@
             "in": "path",
             "description": "Vendor Check ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveCheck" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveCheck"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Check" }
+                "schema": {
+                  "$ref": "#/components/schemas/Check"
+                }
               }
             }
           },
@@ -1916,7 +2476,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1924,7 +2486,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1932,17 +2496,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/bills/{billID}": {
       "get": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Retrieve a bill (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves a specific bill.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BILLS</span> - <code>Read</code>\n",
         "operationId": "getBill",
@@ -1952,7 +2522,10 @@
             "in": "path",
             "description": "Bill ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -1960,7 +2533,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Bill" }
+                "schema": {
+                  "$ref": "#/components/schemas/Bill"
+                }
               }
             }
           },
@@ -1968,7 +2543,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1976,7 +2553,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -1984,15 +2563,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Delete a Bill (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDelete a Bill.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BILLS</span> - <code>Delete</code>\n",
         "operationId": "deleteBill",
@@ -2002,7 +2587,10 @@
             "in": "path",
             "description": "Bill ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -2010,7 +2598,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -2018,7 +2608,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2026,7 +2618,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2034,17 +2628,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/bills/{billId}": {
       "put": {
-        "tags": ["Bills"],
+        "tags": [
+          "Bills"
+        ],
         "summary": "Update a Bill (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdate an existing bill.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BILLS</span> - <code>Write</code>\n",
         "operationId": "updateBill",
@@ -2054,16 +2654,23 @@
             "in": "path",
             "description": "Bill ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveBill" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveBill"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Bill" }
+                "schema": {
+                  "$ref": "#/components/schemas/Bill"
+                }
               }
             }
           },
@@ -2071,7 +2678,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2079,7 +2688,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2087,17 +2698,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/buildings": {
       "get": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Retrieve all buildings",
         "description": "Retrieves a list of buildings.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>idnumber</code>, <code>name</code>, <code>abbreviation</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getBuildings",
@@ -2107,77 +2724,107 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "vacant",
             "in": "query",
             "description": "Filters results by the building's vacancy status. If no value is specified, buildings with any status will be returned.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "publishedForRent",
             "in": "query",
             "description": "Filters results by the building's \"published for rent\" status. If no value is specified, buildings with any status will be returned.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "leaseID",
             "in": "query",
             "description": "Filters results to buildings associated with a specific lease.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results to buildings associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "includeDeactivated",
             "in": "query",
             "description": "Filters results to buildings with a deactivated records.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "Include custom fields in the response.",
             "required": false,
-            "schema": { "type": "boolean", "default": false }
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -2186,14 +2833,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Building" }
+                  "items": {
+                    "$ref": "#/components/schemas/Building"
+                  }
                 }
               }
             }
@@ -2202,7 +2854,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2210,7 +2864,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2218,24 +2874,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Create a building (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a building.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Write</code>\n",
         "operationId": "createBuilding",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveBuilding" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveBuilding"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Building" }
+                "schema": {
+                  "$ref": "#/components/schemas/Building"
+                }
               }
             }
           },
@@ -2243,7 +2907,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2251,7 +2917,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2259,7 +2927,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -2268,7 +2938,9 @@
     },
     "/buildings/bulk": {
       "post": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Create buildings in bulk (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates buildings in bulk.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Write</code>\n",
         "operationId": "createContacts",
@@ -2277,7 +2949,9 @@
             "application/json": {
               "schema": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/SaveBuilding" }
+                "items": {
+                  "$ref": "#/components/schemas/SaveBuilding"
+                }
               }
             }
           },
@@ -2315,7 +2989,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2323,7 +2999,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -2332,7 +3010,9 @@
     },
     "/buildings/{buildingID}": {
       "get": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Retrieve a building",
         "description": "Retrieves a specific building.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Read</code>\n",
         "operationId": "getBuilding",
@@ -2342,14 +3022,20 @@
             "in": "path",
             "description": "Building ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "Include custom fields in the response.",
             "required": false,
-            "schema": { "type": "boolean", "default": true }
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -2357,7 +3043,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Building" }
+                "schema": {
+                  "$ref": "#/components/schemas/Building"
+                }
               }
             }
           },
@@ -2365,7 +3053,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2373,7 +3063,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2381,15 +3073,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "put": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Update a building (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates a building.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Write</code>\n",
         "operationId": "updateBuilding",
@@ -2399,16 +3097,23 @@
             "in": "path",
             "description": "Building ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveBuilding" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveBuilding"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Building" }
+                "schema": {
+                  "$ref": "#/components/schemas/Building"
+                }
               }
             }
           },
@@ -2416,7 +3121,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2424,7 +3131,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2432,15 +3141,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Delete a building (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDelete a building.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Delete</code>\n",
         "operationId": "deleteBuilding",
@@ -2450,7 +3165,10 @@
             "in": "path",
             "description": "Building ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -2458,7 +3176,9 @@
             "description": "No Content",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -2466,7 +3186,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2474,7 +3196,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2482,17 +3206,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/buildings/{buildingID}/conversations": {
       "get": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Retrieve all building conversations",
         "description": "Retrieves all the conversations of a building.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getBuildingConversations",
@@ -2502,42 +3232,60 @@
             "in": "path",
             "description": "Building ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "type",
@@ -2546,7 +3294,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["MANAGEMENT_TEAM", "OWNER", "TENANT"]
+              "enum": [
+                "MANAGEMENT_TEAM",
+                "OWNER",
+                "TENANT"
+              ]
             }
           }
         ],
@@ -2556,14 +3308,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Conversation" }
+                  "items": {
+                    "$ref": "#/components/schemas/Conversation"
+                  }
                 }
               }
             }
@@ -2572,7 +3329,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2580,7 +3339,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2588,17 +3349,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/buildings/{buildingID}/conversations/{conversationID}": {
       "get": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Retrieve a building conversation",
         "description": "Retrieves a specific building conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Read</code>\n",
         "operationId": "getBuildingConversation",
@@ -2608,14 +3375,20 @@
             "in": "path",
             "description": "Building ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -2623,7 +3396,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Conversation" }
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
               }
             }
           },
@@ -2631,7 +3406,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2639,7 +3416,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2647,15 +3426,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Delete a building conversation (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDeletes a specific building conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Delete</code>\n",
         "operationId": "deleteBuildingConversation",
@@ -2665,14 +3450,20 @@
             "in": "path",
             "description": "Building ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -2680,7 +3471,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -2688,7 +3481,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2696,7 +3491,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2704,17 +3501,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/buildings/{buildingID}/managementfees": {
       "get": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Retrieve all building management fees (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves all the management fee rules of a building.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Read</code>\n",
         "operationId": "getBuildingManagementFee",
@@ -2724,7 +3527,10 @@
             "in": "path",
             "description": "Building ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -2734,7 +3540,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/ManagementFee" }
+                  "items": {
+                    "$ref": "#/components/schemas/ManagementFee"
+                  }
                 }
               }
             }
@@ -2743,7 +3551,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2751,7 +3561,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2759,17 +3571,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/buildings/{buildingID}/managers": {
       "get": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Retrieve all building property managers",
         "description": "Retrieves all the property managers of a building.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Read</code>\n",
         "operationId": "getBuildingManagers",
@@ -2779,7 +3597,10 @@
             "in": "path",
             "description": "Building ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -2789,7 +3610,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/PropertyManager" }
+                  "items": {
+                    "$ref": "#/components/schemas/PropertyManager"
+                  }
                 }
               }
             }
@@ -2798,7 +3621,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2806,7 +3631,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2814,17 +3641,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/buildings/{buildingID}/notes": {
       "get": {
-        "tags": ["Buildings"],
+        "tags": [
+          "Buildings"
+        ],
         "summary": "Retrieve all building notes",
         "description": "Retrieves all the notes of a building.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Read</code>\n",
         "operationId": "getBuildingNotes",
@@ -2834,7 +3667,10 @@
             "in": "path",
             "description": "Building ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -2844,7 +3680,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Note" }
+                  "items": {
+                    "$ref": "#/components/schemas/Note"
+                  }
                 }
               }
             }
@@ -2853,7 +3691,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2861,7 +3701,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2869,17 +3711,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/contacts": {
       "get": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Retrieve all contacts",
         "description": "Retrieves a list of contacts.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">CONTACTS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>firstname</code>, <code>createddate</code>, <code>lastname</code>, <code>email</code>, <code>type</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getContacts",
@@ -2889,35 +3737,50 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "type",
@@ -2926,7 +3789,13 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["TENANT", "PROSPECT", "OWNER", "VENDOR", "OTHER"]
+              "enum": [
+                "TENANT",
+                "PROSPECT",
+                "OWNER",
+                "VENDOR",
+                "OTHER"
+              ]
             }
           },
           {
@@ -2934,7 +3803,10 @@
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": false }
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -2943,14 +3815,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Contact" }
+                  "items": {
+                    "$ref": "#/components/schemas/Contact"
+                  }
                 }
               }
             }
@@ -2959,7 +3836,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2967,7 +3846,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -2975,24 +3856,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Create a contact (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a contact.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">CONTACTS</span> - <code>Write</code>\n",
         "operationId": "createContact",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveContact" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveContact"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Contact" }
+                "schema": {
+                  "$ref": "#/components/schemas/Contact"
+                }
               }
             }
           },
@@ -3000,7 +3889,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3008,7 +3899,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3016,7 +3909,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -3025,7 +3920,9 @@
     },
     "/contacts/bulk": {
       "post": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Create contacts in bulk (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates contacts in bulk.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">CONTACTS</span> - <code>Write</code>\n",
         "operationId": "createContactsUsingPOST_1",
@@ -3034,7 +3931,9 @@
             "application/json": {
               "schema": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/SaveContact" }
+                "items": {
+                  "$ref": "#/components/schemas/SaveContact"
+                }
               }
             }
           },
@@ -3072,7 +3971,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3080,7 +3981,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -3089,7 +3992,9 @@
     },
     "/contacts/categories": {
       "get": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Retrieve all contact categories",
         "description": "Retrieves a list of contact categories.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">CONTACTS</span> - <code>Read</code>\n",
         "operationId": "getContactCategories",
@@ -3099,14 +4004,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/ContactCategory" }
+                  "items": {
+                    "$ref": "#/components/schemas/ContactCategory"
+                  }
                 }
               }
             }
@@ -3115,7 +4025,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3123,7 +4035,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3131,7 +4045,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -3140,7 +4056,9 @@
     },
     "/contacts/{contactID}": {
       "get": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Retrieve a contact",
         "description": "Retrieves a specific contact.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">CONTACTS</span> - <code>Read</code>\n",
         "operationId": "getContact",
@@ -3150,14 +4068,20 @@
             "in": "path",
             "description": "Contact ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": true }
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -3165,7 +4089,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Contact" }
+                "schema": {
+                  "$ref": "#/components/schemas/Contact"
+                }
               }
             }
           },
@@ -3173,7 +4099,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3181,7 +4109,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3189,15 +4119,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "put": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Update a contact (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates a contact.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">CONTACTS</span> - <code>Write</code>\n",
         "operationId": "updateContact",
@@ -3207,16 +4143,23 @@
             "in": "path",
             "description": "Contact ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveContact" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveContact"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Contact" }
+                "schema": {
+                  "$ref": "#/components/schemas/Contact"
+                }
               }
             }
           },
@@ -3224,7 +4167,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3232,7 +4177,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3240,15 +4187,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Delete a contact (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDeletes a contact.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">CONTACTS</span> - <code>Delete</code>\n",
         "operationId": "deleteContact",
@@ -3258,7 +4211,10 @@
             "in": "path",
             "description": "Contact ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -3266,7 +4222,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -3274,7 +4232,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3282,7 +4242,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3290,17 +4252,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/contacts/{contactID}/conversations": {
       "get": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Retrieve all contact conversations",
         "description": "Retrieves all the conversations of a contact.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">CONTACTS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getContactConversations",
@@ -3310,42 +4278,60 @@
             "in": "path",
             "description": "Contact ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "type",
@@ -3354,7 +4340,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["MANAGEMENT_TEAM", "OWNER", "TENANT"]
+              "enum": [
+                "MANAGEMENT_TEAM",
+                "OWNER",
+                "TENANT"
+              ]
             }
           }
         ],
@@ -3364,14 +4354,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Conversation" }
+                  "items": {
+                    "$ref": "#/components/schemas/Conversation"
+                  }
                 }
               }
             }
@@ -3380,7 +4375,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3388,7 +4385,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3396,17 +4395,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/contacts/{contactID}/conversations/{conversationID}": {
       "get": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Retrieve a contact conversation",
         "description": "Retrieves a specific contact conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">CONTACTS</span> - <code>Read</code>\n",
         "operationId": "getContactConversation",
@@ -3416,14 +4421,20 @@
             "in": "path",
             "description": "Contact ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -3431,7 +4442,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Conversation" }
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
               }
             }
           },
@@ -3439,7 +4452,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3447,7 +4462,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3455,15 +4472,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Delete a contact conversation (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDeletes a specific contact conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">CONTACTS</span> - <code>Delete</code>\n",
         "operationId": "deleteContactConversation",
@@ -3473,14 +4496,20 @@
             "in": "path",
             "description": "Contact ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -3488,7 +4517,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -3496,7 +4527,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3504,7 +4537,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3512,17 +4547,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/customfields/{entityType}/definitions": {
       "get": {
-        "tags": ["CustomField fields"],
+        "tags": [
+          "CustomField fields"
+        ],
         "summary": "Retrieve list of custom field definitions.",
         "description": "Retrieve list of custom field definitions.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">CUSTOM FIELD</span> - <code>Read</code>\n",
         "operationId": "retrieveCustomFieldDefinitions",
@@ -3532,7 +4573,9 @@
             "in": "path",
             "description": "Entity type, allowed entity types (Asset, Building, Contact, Lease, Portfolio, Prospect, Unit, Vendor, WorkOrder, ServiceAgreement)",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -3553,7 +4596,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3561,7 +4606,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3569,17 +4616,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/docs": {
       "get": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Retrieve all documents",
         "description": "Retrieves a list of documents associated with a specific entity.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">DOCUMENTS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "retrieveAllDocuments",
@@ -3589,35 +4642,50 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "entityType",
@@ -3656,7 +4724,10 @@
             "in": "query",
             "description": "Filters results to documents associated with a specific entity id. entity ID is not required for DESKTOP and OTHER. Remaining entities need entity ID.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -3665,14 +4736,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Document" }
+                  "items": {
+                    "$ref": "#/components/schemas/Document"
+                  }
                 }
               }
             }
@@ -3681,7 +4757,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3689,7 +4767,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3697,14 +4777,18 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Upload a document (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpload a document<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">DOCUMENTS</span> - <code>Write</code>\n",
         "operationId": "uploadDocument",
@@ -3714,35 +4798,47 @@
             "in": "query",
             "description": "Unique identifier of an entity document is attached to.",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "publishToTenantPortal",
             "in": "query",
             "description": "Indicates if the document is published to the tenant portal.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "publishToOwnerPortal",
             "in": "query",
             "description": "Indicates if the document is published to the owner portal.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "entityType",
             "in": "query",
             "description": "Entity type Document is attached to (Asset, Bill, Bank Deposit, Building, Desktop, Lease, Owner, Portfolio, Prospect, Prospect Contact, Tenant, Unit, Vendor, Check, Credit, Service Agreement, Journal Entry, Work Order)",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/octet-stream": {
-              "schema": { "type": "string", "format": "binary" }
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
             }
           }
         },
@@ -3751,7 +4847,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Document" }
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
               }
             }
           },
@@ -3759,7 +4857,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3767,7 +4867,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3775,7 +4877,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -3784,7 +4888,9 @@
     },
     "/docs/{documentId}": {
       "get": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Retrieve a document",
         "description": "Retrieves the metadata of a specific document.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">DOCUMENTS</span> - <code>Read</code>\n",
         "operationId": "retrieveDocument",
@@ -3794,7 +4900,10 @@
             "in": "path",
             "description": "ID of the document to retrieve",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -3802,7 +4911,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Document" }
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
               }
             }
           },
@@ -3810,7 +4921,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3818,7 +4931,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3826,15 +4941,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "put": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Update a document (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates the metadata of a specific document.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">DOCUMENTS</span> - <code>Write</code>\n",
         "operationId": "updateDocument",
@@ -3844,13 +4965,18 @@
             "in": "path",
             "description": "ID of the document to be updated",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/UpdateDocument" }
+              "schema": {
+                "$ref": "#/components/schemas/UpdateDocument"
+              }
             }
           },
           "description": "updateDocument",
@@ -3861,7 +4987,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Document" }
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
               }
             }
           },
@@ -3869,7 +4997,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3877,7 +5007,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3885,15 +5017,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Delete a document (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDeletes a specific document and its associated content.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">DOCUMENTS</span> - <code>Delete</code>\n",
         "operationId": "deleteDocument",
@@ -3903,7 +5041,10 @@
             "in": "path",
             "description": "ID of the document to delete",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -3911,7 +5052,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -3919,7 +5062,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -3927,7 +5072,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3935,7 +5082,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -3943,17 +5092,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/docs/{documentId}/download": {
       "get": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "Download a document",
         "description": "Retrieve a temporary download URL for a specific document.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">DOCUMENTS</span> - <code>Read</code>\n",
         "operationId": "downloadDocument",
@@ -3963,7 +5118,10 @@
             "in": "path",
             "description": "ID of the document to download",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -3972,19 +5130,27 @@
             "headers": {
               "X-Document-Type": {
                 "description": "Header indicates the type of a document",
-                "schema": { "type": "string" }
+                "schema": {
+                  "type": "string"
+                }
               },
               "X-Document-Name": {
                 "description": "Header indicates the name of a document",
-                "schema": { "type": "string" }
+                "schema": {
+                  "type": "string"
+                }
               }
             },
             "content": {
               "application/octet-stream": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               },
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -3992,10 +5158,14 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/octet-stream": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               },
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4003,10 +5173,14 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/octet-stream": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               },
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4014,20 +5188,28 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/octet-stream": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               },
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/health": {
       "get": {
-        "tags": ["Health check"],
+        "tags": [
+          "Health check"
+        ],
         "summary": "Health check",
         "description": "Indicates whether the API is up and running correctly.<br/><br/>",
         "operationId": "health",
@@ -4036,7 +5218,9 @@
             "description": "OK",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -4044,7 +5228,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4052,7 +5238,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4060,7 +5248,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -4069,7 +5259,9 @@
     },
     "/inspections": {
       "get": {
-        "tags": ["Inspections"],
+        "tags": [
+          "Inspections"
+        ],
         "summary": "Retrieve all inspections",
         "description": "Retrieves a list of inspections.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">INSPECTIONS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>number</code>, <code>lastmodifieddatetime</code>, <code>status</code>, <code>id</code>",
         "operationId": "getInspections",
@@ -4079,63 +5271,88 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filters results to inspections with a specific status.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results to inspections associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "buildingID",
             "in": "query",
             "description": "Filters results to inspections associated with a specific building.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "type",
             "in": "query",
             "description": "Filters results to inspections with a specific type.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4144,14 +5361,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Inspection" }
+                  "items": {
+                    "$ref": "#/components/schemas/Inspection"
+                  }
                 }
               }
             }
@@ -4160,7 +5382,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4168,7 +5392,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4176,7 +5402,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -4185,7 +5413,9 @@
     },
     "/inspections/{inspectionId}": {
       "get": {
-        "tags": ["Inspections"],
+        "tags": [
+          "Inspections"
+        ],
         "summary": "Retrieve a inspection",
         "description": "Retrieves a specific inspection.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">INSPECTIONS</span> - <code>Read</code>\n",
         "operationId": "getInspection",
@@ -4195,14 +5425,20 @@
             "in": "path",
             "description": "Inspection ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": true }
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -4210,7 +5446,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Inspection" }
+                "schema": {
+                  "$ref": "#/components/schemas/Inspection"
+                }
               }
             }
           },
@@ -4218,7 +5456,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4226,7 +5466,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4234,17 +5476,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all leases",
         "description": "Retrieves a list of leases.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>startdate</code>, <code>idnumber</code>, <code>scheduledmoveoutdate</code>, <code>enddate</code>, <code>lastmodifieddatetime</code>, <code>status</code>, <code>moveoutdate</code>, <code>id</code>, <code>moveindate</code>",
         "operationId": "getLeases",
@@ -4254,126 +5502,179 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "startDateStart",
             "in": "query",
             "description": "Filters results to any lease with a start date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "startDateEnd",
             "in": "query",
             "description": "Filters results to any lease with a start date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "endDateStart",
             "in": "query",
             "description": "Filters results to any lease with a end date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "endDateEnd",
             "in": "query",
             "description": "Filters results to any lease with a end date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "moveInDateStart",
             "in": "query",
             "description": "Filters results to any lease with a move-in date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "moveInDateEnd",
             "in": "query",
             "description": "Filters results to any lease with a move-in date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "scheduleMoveOutDateStart",
             "in": "query",
             "description": "Filters results to any lease with a move-out date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "scheduleMoveOutDateEnd",
             "in": "query",
             "description": "Filters results to any lease with a move-out date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results to leases associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "buildingID",
             "in": "query",
             "description": "Filters results to leases associated with a specific building.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "unitID",
             "in": "query",
             "description": "Filters results to leases associated with a specific unit.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filters results to inspections with a specific status.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": false }
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -4382,14 +5683,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Lease" }
+                  "items": {
+                    "$ref": "#/components/schemas/Lease"
+                  }
                 }
               }
             }
@@ -4398,7 +5704,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4406,7 +5714,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4414,21 +5724,27 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Create a lease (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a new lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "createLease",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SaveLease" }
+              "schema": {
+                "$ref": "#/components/schemas/SaveLease"
+              }
             }
           },
           "description": "saveLease",
@@ -4439,7 +5755,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Lease" }
+                "schema": {
+                  "$ref": "#/components/schemas/Lease"
+                }
               }
             }
           },
@@ -4447,7 +5765,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4455,7 +5775,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4463,17 +5785,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/adjustments": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all the adjustments",
         "description": "Retrieves a list of adjustments.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>leaseid</code>, <code>postdate</code>, <code>id</code>",
         "operationId": "getLeaseAdjustments",
@@ -4483,70 +5811,99 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "postDateStart",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "postDateEnd",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "leaseID",
             "in": "query",
             "description": "Filters results with Lease ID.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filters results to with Lease Status.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4555,14 +5912,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Adjustment" }
+                  "items": {
+                    "$ref": "#/components/schemas/Adjustment"
+                  }
                 }
               }
             }
@@ -4571,7 +5933,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4579,7 +5943,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4587,24 +5953,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Create a lease adjustment (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a lease adjustment.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "createLeaseAdjustment",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveAdjustment" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveAdjustment"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Adjustment" }
+                "schema": {
+                  "$ref": "#/components/schemas/Adjustment"
+                }
               }
             }
           },
@@ -4612,7 +5986,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4620,7 +5996,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4628,7 +6006,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -4637,7 +6017,9 @@
     },
     "/leases/adjustments/{adjustmentID}": {
       "put": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Update a lease adjustment (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates an lease adjustment.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "updateLeaseAdjustment",
@@ -4647,16 +6029,23 @@
             "in": "path",
             "description": "Adjustment ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveAdjustment" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveAdjustment"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Adjustment" }
+                "schema": {
+                  "$ref": "#/components/schemas/Adjustment"
+                }
               }
             }
           },
@@ -4664,7 +6053,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4672,7 +6063,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4680,17 +6073,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/charges": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all the lease charges",
         "description": "Retrieves a list of lease charges.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>leaseid</code>, <code>postdate</code>, <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getLeaseCharges",
@@ -4700,70 +6099,99 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "postDateStart",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "postDateEnd",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "leaseID",
             "in": "query",
             "description": "Filters results with Lease ID.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filters results to with Lease Status.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4772,14 +6200,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/ChargeTx" }
+                  "items": {
+                    "$ref": "#/components/schemas/ChargeTx"
+                  }
                 }
               }
             }
@@ -4788,7 +6221,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4796,7 +6231,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4804,24 +6241,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Create a lease charge (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a lease charge.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "createLeaseCharge",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveCharge" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveCharge"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ChargeTx" }
+                "schema": {
+                  "$ref": "#/components/schemas/ChargeTx"
+                }
               }
             }
           },
@@ -4829,7 +6274,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4837,7 +6284,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4845,7 +6294,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -4854,7 +6305,9 @@
     },
     "/leases/charges/bulk": {
       "post": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Create lease charges in bulk (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates lease charges in bulk.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "createLeaseCharges",
@@ -4863,7 +6316,9 @@
             "application/json": {
               "schema": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/SaveCharge" }
+                "items": {
+                  "$ref": "#/components/schemas/SaveCharge"
+                }
               }
             }
           },
@@ -4901,7 +6356,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4909,7 +6366,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -4918,7 +6377,9 @@
     },
     "/leases/charges/{chargeID}": {
       "put": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Update a lease charge (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates a lease charge.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "updateLeaseCharge",
@@ -4928,16 +6389,23 @@
             "in": "path",
             "description": "Charge ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveCharge" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveCharge"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ChargeTx" }
+                "schema": {
+                  "$ref": "#/components/schemas/ChargeTx"
+                }
               }
             }
           },
@@ -4945,7 +6413,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4953,7 +6423,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -4961,17 +6433,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/creditmemos": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all the credit memos",
         "description": "Retrieves a list of credit memos.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>leaseid</code>, <code>postdate</code>, <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getLeaseCreditMemos",
@@ -4981,70 +6459,99 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "postDateStart",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "postDateEnd",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "leaseID",
             "in": "query",
             "description": "Filters results with Lease ID.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filters results to with Lease Status.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5054,7 +6561,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/CreditMemo" }
+                  "items": {
+                    "$ref": "#/components/schemas/CreditMemo"
+                  }
                 }
               }
             }
@@ -5063,7 +6572,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5071,7 +6582,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5079,17 +6592,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/discounts": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all the lease discounts",
         "description": "Retrieves a list of lease discounts<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>leaseid</code>, <code>postdate</code>, <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getLeaseDiscounts",
@@ -5099,56 +6618,80 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "leaseID",
             "in": "query",
             "description": "Filters results to any LeaseID.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "postDateStart",
             "in": "query",
             "description": "Filters results to any discount with a start date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "postDateEnd",
             "in": "query",
             "description": "Filters results to any discount with a start date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           }
         ],
         "responses": {
@@ -5157,14 +6700,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Discount" }
+                  "items": {
+                    "$ref": "#/components/schemas/Discount"
+                  }
                 }
               }
             }
@@ -5173,7 +6721,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5181,7 +6731,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5189,24 +6741,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Create a lease discount (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a lease discount.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "createLeaseDiscount",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveDiscount" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveDiscount"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Discount" }
+                "schema": {
+                  "$ref": "#/components/schemas/Discount"
+                }
               }
             }
           },
@@ -5214,7 +6774,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5222,7 +6784,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5230,7 +6794,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -5239,7 +6805,9 @@
     },
     "/leases/discounts/{discountID}": {
       "put": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Updates a lease Discount (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates a lease Discount.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "updateLeaseDiscount",
@@ -5249,16 +6817,23 @@
             "in": "path",
             "description": "Discount ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveDiscount" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveDiscount"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Discount" }
+                "schema": {
+                  "$ref": "#/components/schemas/Discount"
+                }
               }
             }
           },
@@ -5266,7 +6841,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5274,7 +6851,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5282,24 +6861,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/journalentries": {
       "post": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Create a lease journal entry (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a lease journal entry.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "createJournalEntry",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SaveLeaseJournalEntry" }
+              "schema": {
+                "$ref": "#/components/schemas/SaveLeaseJournalEntry"
+              }
             }
           },
           "description": "saveLeaseJournalEntry",
@@ -5310,7 +6897,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/JournalEntry" }
+                "schema": {
+                  "$ref": "#/components/schemas/JournalEntry"
+                }
               }
             }
           },
@@ -5318,7 +6907,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5326,7 +6917,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5334,7 +6927,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -5343,7 +6938,9 @@
     },
     "/leases/journalentries/{journalentryID}": {
       "put": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Update a lease journal entry (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates a lease journal entry.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n<br/><br/><b>Sortable by:</b> <code>postdate</code>, <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "updateLeaseJournalEntry",
@@ -5353,7 +6950,10 @@
             "in": "path",
             "description": "Journal Entry ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "requestBody": {
@@ -5372,7 +6972,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/JournalEntry" }
+                "schema": {
+                  "$ref": "#/components/schemas/JournalEntry"
+                }
               }
             }
           },
@@ -5380,7 +6982,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5388,7 +6992,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5396,17 +7002,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/journalentries/{leaseID}": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all lease journal entries ",
         "description": "Retrieves a specific lease journal entries.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLeaseJournalEntry",
@@ -5416,63 +7028,90 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "leaseID",
             "in": "query",
             "description": "Filters results to transactions associated with a specific lease.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "postDateStart",
             "in": "query",
             "description": "Filters results to any transaction with post date on or after to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "postDateEnd",
             "in": "query",
             "description": "Filters results to any transaction with post date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           }
         ],
         "responses": {
@@ -5481,12 +7120,17 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/JournalEntry" }
+                "schema": {
+                  "$ref": "#/components/schemas/JournalEntry"
+                }
               }
             }
           },
@@ -5494,7 +7138,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5502,7 +7148,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5510,17 +7158,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/payments": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all the lease payments",
         "description": "Retrieves a list of lease payments.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>leaseid</code>, <code>postdate</code>, <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getLeasePayments",
@@ -5530,70 +7184,99 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "postDateStart",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "postDateEnd",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "leaseID",
             "in": "query",
             "description": "Filters results with Lease ID.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filters results to with Lease Status.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5602,14 +7285,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Payment" }
+                  "items": {
+                    "$ref": "#/components/schemas/Payment"
+                  }
                 }
               }
             }
@@ -5618,7 +7306,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5626,7 +7316,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5634,24 +7326,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Create a lease payment (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a lease payment.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "createLeasePayment",
-        "requestBody": { "$ref": "#/components/requestBodies/SavePayment" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SavePayment"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Payment" }
+                "schema": {
+                  "$ref": "#/components/schemas/Payment"
+                }
               }
             }
           },
@@ -5659,7 +7359,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5667,7 +7369,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5675,7 +7379,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -5684,7 +7390,9 @@
     },
     "/leases/payments/{entityID}": {
       "put": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Update a lease payment (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates a lease payment.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "updateLeasePayment",
@@ -5694,16 +7402,23 @@
             "in": "path",
             "description": "Lease Payment ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SavePayment" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SavePayment"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Payment" }
+                "schema": {
+                  "$ref": "#/components/schemas/Payment"
+                }
               }
             }
           },
@@ -5711,7 +7426,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5719,7 +7436,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5727,17 +7446,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/refunds": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all the tenant refunds",
         "description": "Retrieves a list of tenant refunds.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>leaseid</code>, <code>postdate</code>, <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getLeaseRefunds",
@@ -5747,70 +7472,99 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "postDateStart",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or after the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "postDateEnd",
             "in": "query",
             "description": "Filters results to any transaction with a start date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "leaseID",
             "in": "query",
             "description": "Filters results with Lease ID.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filters results to with Lease Status.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -5819,14 +7573,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Refund" }
+                  "items": {
+                    "$ref": "#/components/schemas/Refund"
+                  }
                 }
               }
             }
@@ -5835,7 +7594,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5843,7 +7604,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5851,24 +7614,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Create a lease refund (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a lease refund.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "createLeaseRefund",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveRefund" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveRefund"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Refund" }
+                "schema": {
+                  "$ref": "#/components/schemas/Refund"
+                }
               }
             }
           },
@@ -5876,7 +7647,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5884,7 +7657,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5892,7 +7667,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -5901,7 +7678,9 @@
     },
     "/leases/refunds/{refundID}": {
       "put": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Update a lease refund (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdate an lease refund.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "updateLeaseRefund",
@@ -5911,16 +7690,23 @@
             "in": "path",
             "description": "Refund ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveRefund" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveRefund"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Refund" }
+                "schema": {
+                  "$ref": "#/components/schemas/Refund"
+                }
               }
             }
           },
@@ -5928,7 +7714,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5936,7 +7724,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5944,17 +7734,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/statuses": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all lease statuses (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves a list of all lease statuses<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getAllLeaseStatuses",
@@ -5965,7 +7761,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/LeaseStatus" }
+                  "items": {
+                    "$ref": "#/components/schemas/LeaseStatus"
+                  }
                 }
               }
             }
@@ -5974,7 +7772,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5982,7 +7782,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -5990,17 +7792,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseID}": {
       "delete": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Delete a lease (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDeletes a lease<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Delete</code>\n",
         "operationId": "deleteLease",
@@ -6010,7 +7818,10 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -6018,7 +7829,9 @@
             "description": "No Content",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -6026,7 +7839,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6034,7 +7849,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6042,17 +7859,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseID}/conversations": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all lease conversations",
         "description": "Retrieves all the conversations of a lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getLeaseConversations",
@@ -6062,42 +7885,60 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "type",
@@ -6106,7 +7947,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["MANAGEMENT_TEAM", "OWNER", "TENANT"]
+              "enum": [
+                "MANAGEMENT_TEAM",
+                "OWNER",
+                "TENANT"
+              ]
             }
           }
         ],
@@ -6116,14 +7961,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Conversation" }
+                  "items": {
+                    "$ref": "#/components/schemas/Conversation"
+                  }
                 }
               }
             }
@@ -6132,7 +7982,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6140,7 +7992,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6148,15 +8002,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "post": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Create a lease conversation (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a specific lease conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "createLeaseConversation",
@@ -6166,7 +8026,10 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "requestBody": {
@@ -6177,7 +8040,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Conversation" }
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
               }
             }
           },
@@ -6185,7 +8050,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6193,7 +8060,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6201,17 +8070,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseID}/conversations/{conversationID}": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve a lease conversation",
         "description": "Retrieves a specific lease conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLeaseConversation",
@@ -6221,14 +8096,20 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -6236,7 +8117,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Conversation" }
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
               }
             }
           },
@@ -6244,7 +8127,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6252,7 +8137,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6260,15 +8147,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Delete a lease conversation (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDeletes a specific lease conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Delete</code>\n",
         "operationId": "deleteLeaseConversation",
@@ -6278,14 +8171,20 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -6293,7 +8192,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -6301,7 +8202,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6309,7 +8212,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6317,17 +8222,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseID}/conversations/{conversationID}/comments": {
       "post": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Add comment to a lease conversation (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nAdds comment to a lease conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "addCommentToLeaseConversation",
@@ -6337,20 +8248,28 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SaveComment" }
+              "schema": {
+                "$ref": "#/components/schemas/SaveComment"
+              }
             }
           },
           "description": "saveComment",
@@ -6361,7 +8280,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Comment" }
+                "schema": {
+                  "$ref": "#/components/schemas/Comment"
+                }
               }
             }
           },
@@ -6369,7 +8290,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6377,7 +8300,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6385,17 +8310,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseId}": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve a lease",
         "description": "Retrieves a specific lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLease",
@@ -6405,14 +8336,20 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": true }
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -6420,7 +8357,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Lease" }
+                "schema": {
+                  "$ref": "#/components/schemas/Lease"
+                }
               }
             }
           },
@@ -6428,7 +8367,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6436,7 +8377,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6444,15 +8387,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "put": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Update a lease (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates an existing lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Write</code>\n",
         "operationId": "updateLease",
@@ -6462,13 +8411,18 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SaveLease" }
+              "schema": {
+                "$ref": "#/components/schemas/SaveLease"
+              }
             }
           },
           "description": "lease",
@@ -6479,7 +8433,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Lease" }
+                "schema": {
+                  "$ref": "#/components/schemas/Lease"
+                }
               }
             }
           },
@@ -6487,7 +8443,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6495,7 +8453,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6503,17 +8463,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseId}/autocharges": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all lease auto charges",
         "description": "Retrieves all the auto charges of a lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLeaseAutoCharges",
@@ -6523,7 +8489,10 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -6533,7 +8502,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Charge" }
+                  "items": {
+                    "$ref": "#/components/schemas/Charge"
+                  }
                 }
               }
             }
@@ -6542,7 +8513,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6550,7 +8523,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6558,17 +8533,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseId}/autoepayments": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all lease auto ePayments (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves all the auto ePayments of a lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLeaseAutoEPayments",
@@ -6578,7 +8559,10 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -6586,7 +8570,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AutoPayment" }
+                "schema": {
+                  "$ref": "#/components/schemas/AutoPayment"
+                }
               }
             }
           },
@@ -6594,7 +8580,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6602,7 +8590,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6610,17 +8600,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseId}/autojournalentries": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all lease auto journal entries (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves all the auto journal entries of a lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLeaseAutoJournalEntries",
@@ -6630,7 +8626,10 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -6638,7 +8637,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AutoJournalEntry" }
+                "schema": {
+                  "$ref": "#/components/schemas/AutoJournalEntry"
+                }
               }
             }
           },
@@ -6646,7 +8647,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6654,7 +8657,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6662,17 +8667,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseId}/contacts": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all lease contacts",
         "description": "Retrieves all the contacts of a lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLeaseContacts",
@@ -6682,14 +8693,19 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "Include contact custom fields in the response.",
             "in": "query",
             "description": "Include contact custom fields in the response.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -6699,7 +8715,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Contact" }
+                  "items": {
+                    "$ref": "#/components/schemas/Contact"
+                  }
                 }
               }
             }
@@ -6708,7 +8726,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6716,7 +8736,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6724,17 +8746,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseId}/customfields": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all lease custom fields",
         "description": "Retrieves all the custom fields of a lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLeaseCustomFields",
@@ -6744,7 +8772,10 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -6754,7 +8785,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/CustomField" }
+                  "items": {
+                    "$ref": "#/components/schemas/CustomField"
+                  }
                 }
               }
             }
@@ -6763,7 +8796,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6771,7 +8806,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6779,17 +8816,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseId}/document": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all lease documents",
         "description": "Retrieves all the documents of a lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLeaseDocuments",
@@ -6799,7 +8842,10 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -6809,7 +8855,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Document" }
+                  "items": {
+                    "$ref": "#/components/schemas/Document"
+                  }
                 }
               }
             }
@@ -6818,7 +8866,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6826,7 +8876,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6834,17 +8886,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseId}/latefeerule": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve the lease late fee rule",
         "description": "Retrieves the lease late fee rule.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLeaseLateFee",
@@ -6854,7 +8912,10 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -6862,7 +8923,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/LateFeeRule" }
+                "schema": {
+                  "$ref": "#/components/schemas/LateFeeRule"
+                }
               }
             }
           },
@@ -6870,7 +8933,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6878,7 +8943,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6886,17 +8953,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseId}/notes": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all lease notes",
         "description": "Retrieves all the notes of a lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLeaseNotes",
@@ -6906,7 +8979,10 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -6916,7 +8992,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Note" }
+                  "items": {
+                    "$ref": "#/components/schemas/Note"
+                  }
                 }
               }
             }
@@ -6925,7 +9003,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6933,7 +9013,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6941,17 +9023,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/leases/{leaseId}/workorders": {
       "get": {
-        "tags": ["Leases"],
+        "tags": [
+          "Leases"
+        ],
         "summary": "Retrieve all lease work orders",
         "description": "Retrieves all the work orders of a lease.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">LEASES</span> - <code>Read</code>\n",
         "operationId": "getLeaseWorkOrders",
@@ -6961,7 +9049,10 @@
             "in": "path",
             "description": "Lease ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -6971,7 +9062,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/WorkOrder" }
+                  "items": {
+                    "$ref": "#/components/schemas/WorkOrder"
+                  }
                 }
               }
             }
@@ -6980,7 +9073,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6988,7 +9083,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -6996,17 +9093,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/portfolios": {
       "get": {
-        "tags": ["Portfolios"],
+        "tags": [
+          "Portfolios"
+        ],
         "summary": "Retrieve all portfolios",
         "description": "Retrieves a list of portfolios.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>name</code>, <code>abbreviation</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getPortfolios",
@@ -7016,49 +9119,69 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "includeDeactivated",
             "in": "query",
             "description": "Filters results to portfolios with a deactivated records.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": false }
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -7067,14 +9190,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Portfolio" }
+                  "items": {
+                    "$ref": "#/components/schemas/Portfolio"
+                  }
                 }
               }
             }
@@ -7083,7 +9211,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7091,7 +9221,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7099,24 +9231,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Portfolios"],
+        "tags": [
+          "Portfolios"
+        ],
         "summary": "Create a portfolio (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a portfolio.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Write</code>\n",
         "operationId": "createPortfolio",
-        "requestBody": { "$ref": "#/components/requestBodies/SavePortfolio" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SavePortfolio"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Portfolio" }
+                "schema": {
+                  "$ref": "#/components/schemas/Portfolio"
+                }
               }
             }
           },
@@ -7124,7 +9264,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7132,7 +9274,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7140,7 +9284,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -7149,7 +9295,9 @@
     },
     "/portfolios/bulk": {
       "post": {
-        "tags": ["Portfolios"],
+        "tags": [
+          "Portfolios"
+        ],
         "summary": "Create Portfolios in bulk (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates Portfolios in bulk.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Write</code>\n",
         "operationId": "createContactsUsingPOST_2",
@@ -7158,7 +9306,9 @@
             "application/json": {
               "schema": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/SavePortfolio" }
+                "items": {
+                  "$ref": "#/components/schemas/SavePortfolio"
+                }
               }
             }
           },
@@ -7196,7 +9346,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7204,7 +9356,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -7213,7 +9367,9 @@
     },
     "/portfolios/{portfolioID}": {
       "get": {
-        "tags": ["Portfolios"],
+        "tags": [
+          "Portfolios"
+        ],
         "summary": "Retrieve a portfolio",
         "description": "Retrieves a specific portfolio.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Read</code>\n",
         "operationId": "getPortfolio",
@@ -7223,14 +9379,20 @@
             "in": "path",
             "description": "Portfolio ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": true }
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -7238,7 +9400,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Portfolio" }
+                "schema": {
+                  "$ref": "#/components/schemas/Portfolio"
+                }
               }
             }
           },
@@ -7246,7 +9410,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7254,7 +9420,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7262,15 +9430,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "put": {
-        "tags": ["Portfolios"],
+        "tags": [
+          "Portfolios"
+        ],
         "summary": "Update a portfolio (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdates an existing portfolio.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Write</code>\n",
         "operationId": "updatePortfolio",
@@ -7280,16 +9454,23 @@
             "in": "path",
             "description": "Portfolio ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SavePortfolio" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SavePortfolio"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Portfolio" }
+                "schema": {
+                  "$ref": "#/components/schemas/Portfolio"
+                }
               }
             }
           },
@@ -7297,7 +9478,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7305,7 +9488,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7313,17 +9498,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/portfolios/{portfolioID}/conversations": {
       "get": {
-        "tags": ["Portfolios"],
+        "tags": [
+          "Portfolios"
+        ],
         "summary": "Retrieve all portfolio conversations",
         "description": "Retrieves all the conversations of a portfolio.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getPortfolioConversations",
@@ -7333,42 +9524,60 @@
             "in": "path",
             "description": "Portfolio ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "type",
@@ -7377,7 +9586,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["MANAGEMENT_TEAM", "OWNER", "TENANT"]
+              "enum": [
+                "MANAGEMENT_TEAM",
+                "OWNER",
+                "TENANT"
+              ]
             }
           }
         ],
@@ -7387,14 +9600,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Conversation" }
+                  "items": {
+                    "$ref": "#/components/schemas/Conversation"
+                  }
                 }
               }
             }
@@ -7403,7 +9621,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7411,7 +9631,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7419,17 +9641,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/portfolios/{portfolioID}/conversations/{conversationID}": {
       "get": {
-        "tags": ["Portfolios"],
+        "tags": [
+          "Portfolios"
+        ],
         "summary": "Retrieve a portfolio conversation",
         "description": "Retrieves a specific portfolio conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Read</code>\n",
         "operationId": "getPortfolioConversation",
@@ -7439,14 +9667,20 @@
             "in": "path",
             "description": "Portfolio ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -7454,7 +9688,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Conversation" }
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
               }
             }
           },
@@ -7462,7 +9698,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7470,7 +9708,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7478,15 +9718,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Portfolios"],
+        "tags": [
+          "Portfolios"
+        ],
         "summary": "Delete a portfolio conversation (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDeletes a specific portfolio conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PORTFOLIOS</span> - <code>Delete</code>\n",
         "operationId": "deletePortfolioConversation",
@@ -7496,14 +9742,20 @@
             "in": "path",
             "description": "Portfolio ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -7511,7 +9763,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -7519,7 +9773,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7527,7 +9783,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7535,17 +9793,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/prospects": {
       "get": {
-        "tags": ["Prospects"],
+        "tags": [
+          "Prospects"
+        ],
         "summary": "Retrieve all prospects",
         "description": "Retrieves a list of prospects.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PROSPECTS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>type</code>, <code>lastmodifieddatetime</code>, <code>status</code>, <code>id</code>",
         "operationId": "getProspects",
@@ -7555,70 +9819,98 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filters results to prospects with a specific status.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results to prospects associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "buildingID",
             "in": "query",
             "description": "Filters results to prospects associated with a specific building.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "type",
             "in": "query",
             "description": "Filters results to prospects with a specific type.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": false }
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -7627,14 +9919,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Prospect" }
+                  "items": {
+                    "$ref": "#/components/schemas/Prospect"
+                  }
                 }
               }
             }
@@ -7643,7 +9940,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7651,7 +9950,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7659,21 +9960,27 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Prospects"],
+        "tags": [
+          "Prospects"
+        ],
         "summary": "Create a prospect (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a specific prospect.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PROSPECTS</span> - <code>Write</code>\n",
         "operationId": "createProspect",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SaveProspect" }
+              "schema": {
+                "$ref": "#/components/schemas/SaveProspect"
+              }
             }
           },
           "description": "saveProspect",
@@ -7684,7 +9991,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Prospect" }
+                "schema": {
+                  "$ref": "#/components/schemas/Prospect"
+                }
               }
             }
           },
@@ -7692,7 +10001,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7700,7 +10011,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7708,17 +10021,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/prospects/bulk": {
       "post": {
-        "tags": ["Prospects"],
+        "tags": [
+          "Prospects"
+        ],
         "summary": "Create prospects in bulk (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates prospects in bulk.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">UNITS</span> - <code>Write</code>\n",
         "operationId": "createContactsUsingPOST_3",
@@ -7727,7 +10046,9 @@
             "application/json": {
               "schema": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/SaveProspect" }
+                "items": {
+                  "$ref": "#/components/schemas/SaveProspect"
+                }
               }
             }
           },
@@ -7765,7 +10086,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7773,7 +10096,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -7782,7 +10107,9 @@
     },
     "/prospects/statuses": {
       "get": {
-        "tags": ["Prospects"],
+        "tags": [
+          "Prospects"
+        ],
         "summary": "Retrieve all prospect statuses (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves a list of all prospect statuses<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PROSPECTS</span> - <code>Read</code>\n",
         "operationId": "getProspectStatuses",
@@ -7793,7 +10120,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/ProspectStatus" }
+                  "items": {
+                    "$ref": "#/components/schemas/ProspectStatus"
+                  }
                 }
               }
             }
@@ -7802,7 +10131,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7810,7 +10141,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7818,17 +10151,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/prospects/{prospectID}": {
       "get": {
-        "tags": ["Prospects"],
+        "tags": [
+          "Prospects"
+        ],
         "summary": "Retrieve a prospect",
         "description": "Retrieves a specific prospect.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PROSPECTS</span> - <code>Read</code>\n",
         "operationId": "getProspect",
@@ -7838,14 +10177,20 @@
             "in": "path",
             "description": "Prospect ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": true }
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -7853,7 +10198,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Prospect" }
+                "schema": {
+                  "$ref": "#/components/schemas/Prospect"
+                }
               }
             }
           },
@@ -7861,7 +10208,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7869,7 +10218,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7877,17 +10228,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/prospects/{prospectID}/campaign": {
       "get": {
-        "tags": ["Prospects"],
+        "tags": [
+          "Prospects"
+        ],
         "summary": "Retrieve prospect campaign",
         "description": "Retrieves the campaign details of a prospect.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PROSPECTS</span> - <code>Read</code>\n",
         "operationId": "getProspectCampaign",
@@ -7897,7 +10254,10 @@
             "in": "path",
             "description": "Prospect ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -7905,7 +10265,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Campaign" }
+                "schema": {
+                  "$ref": "#/components/schemas/Campaign"
+                }
               }
             }
           },
@@ -7913,7 +10275,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -7921,7 +10285,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7929,7 +10295,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -7937,17 +10305,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/prospects/{prospectID}/conversations": {
       "get": {
-        "tags": ["Prospects"],
+        "tags": [
+          "Prospects"
+        ],
         "summary": "Retrieve all prospect conversations",
         "description": "Retrieves all the conversations of a prospect.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PROSPECTS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getProspectConversations",
@@ -7957,42 +10331,60 @@
             "in": "path",
             "description": "Prospect ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "type",
@@ -8001,7 +10393,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["MANAGEMENT_TEAM", "OWNER", "TENANT"]
+              "enum": [
+                "MANAGEMENT_TEAM",
+                "OWNER",
+                "TENANT"
+              ]
             }
           }
         ],
@@ -8011,14 +10407,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Conversation" }
+                  "items": {
+                    "$ref": "#/components/schemas/Conversation"
+                  }
                 }
               }
             }
@@ -8027,7 +10428,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8035,7 +10438,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8043,15 +10448,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "post": {
-        "tags": ["Prospects"],
+        "tags": [
+          "Prospects"
+        ],
         "summary": "Create a prospect conversation (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a specific prospect conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PROSPECTS</span> - <code>Write</code>\n",
         "operationId": "createProspectConversation",
@@ -8061,7 +10472,10 @@
             "in": "path",
             "description": "Prospect ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "requestBody": {
@@ -8072,7 +10486,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Conversation" }
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
               }
             }
           },
@@ -8080,7 +10496,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8088,7 +10506,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8096,17 +10516,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/prospects/{prospectID}/conversations/{conversationID}": {
       "get": {
-        "tags": ["Prospects"],
+        "tags": [
+          "Prospects"
+        ],
         "summary": "Retrieve a prospect conversation",
         "description": "Retrieves a specific prospect conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PROSPECTS</span> - <code>Read</code>\n",
         "operationId": "getProspectConversation",
@@ -8116,14 +10542,20 @@
             "in": "path",
             "description": "Prospect ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -8131,7 +10563,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Conversation" }
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
               }
             }
           },
@@ -8139,7 +10573,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8147,7 +10583,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8155,15 +10593,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Prospects"],
+        "tags": [
+          "Prospects"
+        ],
         "summary": "Delete a prospect conversation (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDeletes a specific prospect conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">PROSPECTS</span> - <code>Delete</code>\n",
         "operationId": "deleteProspectConversation",
@@ -8173,14 +10617,20 @@
             "in": "path",
             "description": "Prospect ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -8188,7 +10638,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -8196,7 +10648,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8204,7 +10658,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8212,17 +10668,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/units": {
       "get": {
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "summary": "Retrieve all units",
         "description": "Retrieves a list of units.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">UNITS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>idnumber</code>, <code>name</code>, <code>abbreviation</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getUnits",
@@ -8232,84 +10694,116 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "vacant",
             "in": "query",
             "description": "Filters results by the unit's vacancy status. If no value is specified, units with any status will be returned.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "publishedForRent",
             "in": "query",
             "description": "Filters results by the unit's \"published for rent\" status. If no value is specified, units with any status will be returned.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results to units associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "buildingID",
             "in": "query",
             "description": "Filters results to units associated with a specific building.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "type",
             "in": "query",
             "description": "Filters results to units with a specific type.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "includeDeactivated",
             "in": "query",
             "description": "Include inactive units in the results.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": false }
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -8318,14 +10812,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Unit" }
+                  "items": {
+                    "$ref": "#/components/schemas/Unit"
+                  }
                 }
               }
             }
@@ -8334,7 +10833,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8342,7 +10843,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8350,24 +10853,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "summary": "Create a unit (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a unit.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">UNITS</span> - <code>Write</code>\n",
         "operationId": "createUnit",
-        "requestBody": { "$ref": "#/components/requestBodies/SaveUnit" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveUnit"
+        },
         "responses": {
           "201": {
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Unit" }
+                "schema": {
+                  "$ref": "#/components/schemas/Unit"
+                }
               }
             }
           },
@@ -8375,7 +10886,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8383,7 +10896,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8391,7 +10906,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -8400,7 +10917,9 @@
     },
     "/units/bulk": {
       "post": {
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "summary": "Create units in bulk (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates units in bulk.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">BUILDINGS</span> - <code>Write</code>\n",
         "operationId": "createContactsUsingPOST_4",
@@ -8409,7 +10928,9 @@
             "application/json": {
               "schema": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/SaveUnit" }
+                "items": {
+                  "$ref": "#/components/schemas/SaveUnit"
+                }
               }
             }
           },
@@ -8447,7 +10968,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8455,7 +10978,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -8464,7 +10989,9 @@
     },
     "/units/{unitID}": {
       "get": {
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "summary": "Retrieve a unit",
         "description": "Retrieves a specific unit.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">UNITS</span> - <code>Read</code>\n",
         "operationId": "getUnit",
@@ -8474,14 +11001,20 @@
             "in": "path",
             "description": "Unit ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": true }
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -8489,7 +11022,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Unit" }
+                "schema": {
+                  "$ref": "#/components/schemas/Unit"
+                }
               }
             }
           },
@@ -8497,7 +11032,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8505,7 +11042,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8513,15 +11052,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "put": {
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "summary": "Update a unit (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdate as unit.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">UNITS</span> - <code>Write</code>\n",
         "operationId": "updateUnit",
@@ -8531,16 +11076,23 @@
             "in": "path",
             "description": "Unit ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
-        "requestBody": { "$ref": "#/components/requestBodies/SaveUnit" },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SaveUnit"
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Unit" }
+                "schema": {
+                  "$ref": "#/components/schemas/Unit"
+                }
               }
             }
           },
@@ -8548,7 +11100,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8556,7 +11110,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8564,15 +11120,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "summary": "Delete a unit (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDeletes a specific unit.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">UNITS</span> - <code>Delete</code>\n",
         "operationId": "deleteUnit",
@@ -8582,7 +11144,10 @@
             "in": "path",
             "description": "Unit ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -8590,7 +11155,9 @@
             "description": "No Content",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -8598,7 +11165,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8606,7 +11175,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8614,17 +11185,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "*/*": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/units/{unitID}/conversations": {
       "get": {
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "summary": "Retrieve all unit conversations",
         "description": "Retrieves all the conversations of a unit.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">UNITS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getUnitConversations",
@@ -8634,42 +11211,60 @@
             "in": "path",
             "description": "Unit ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "type",
@@ -8678,7 +11273,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["MANAGEMENT_TEAM", "OWNER", "TENANT"]
+              "enum": [
+                "MANAGEMENT_TEAM",
+                "OWNER",
+                "TENANT"
+              ]
             }
           }
         ],
@@ -8688,14 +11287,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Conversation" }
+                  "items": {
+                    "$ref": "#/components/schemas/Conversation"
+                  }
                 }
               }
             }
@@ -8704,7 +11308,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8712,7 +11318,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8720,17 +11328,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/units/{unitID}/conversations/{conversationID}": {
       "get": {
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "summary": "Retrieve a unit conversation",
         "description": "Retrieves a specific unit conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">UNITS</span> - <code>Read</code>\n",
         "operationId": "getUnitConversation",
@@ -8740,14 +11354,20 @@
             "in": "path",
             "description": "Unit ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -8755,7 +11375,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Conversation" }
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
               }
             }
           },
@@ -8763,7 +11385,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8771,7 +11395,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8779,15 +11405,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "summary": "Delete a unit conversation (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDeletes a specific unit conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">UNITS</span> - <code>Delete</code>\n",
         "operationId": "deleteUnitConversation",
@@ -8797,14 +11429,20 @@
             "in": "path",
             "description": "Unit ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -8812,7 +11450,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -8820,7 +11460,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8828,7 +11470,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8836,17 +11480,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/units/{unitID}/customFields": {
       "get": {
-        "tags": ["Units"],
+        "tags": [
+          "Units"
+        ],
         "summary": "Retrieve all unit custom fields",
         "description": "Retrieves all the custom fields of a unit.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">UNITS</span> - <code>Read</code>\n",
         "operationId": "getLeaseCustomFieldsUsingGET_1",
@@ -8856,7 +11506,10 @@
             "in": "path",
             "description": "Unit ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -8866,7 +11519,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Unit" }
+                  "items": {
+                    "$ref": "#/components/schemas/Unit"
+                  }
                 }
               }
             }
@@ -8875,7 +11530,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8883,7 +11540,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8891,17 +11550,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/vendors": {
       "get": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Retrieve all vendors",
         "description": "Retrieves a list of vendors.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>vendortype</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getVendors",
@@ -8911,56 +11576,78 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "active",
             "in": "query",
             "description": "Filters results by the vendor's status. If no value is specified, vendors with any status will be returned.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "type",
             "in": "query",
             "description": "Filters results to units with a specific type.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": false }
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -8969,14 +11656,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Vendor" }
+                  "items": {
+                    "$ref": "#/components/schemas/Vendor"
+                  }
                 }
               }
             }
@@ -8985,7 +11677,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -8993,7 +11687,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9001,21 +11697,27 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Create a vendor (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a vendor.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Write</code>\n",
         "operationId": "createVendor",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SaveVendor" }
+              "schema": {
+                "$ref": "#/components/schemas/SaveVendor"
+              }
             }
           },
           "description": "saveVendor",
@@ -9026,7 +11728,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Vendor" }
+                "schema": {
+                  "$ref": "#/components/schemas/Vendor"
+                }
               }
             }
           },
@@ -9034,7 +11738,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9042,7 +11748,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9050,7 +11758,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -9059,7 +11769,9 @@
     },
     "/vendors/bulk": {
       "post": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Create Vendors in bulk (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates Vendors in bulk.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Write</code>\n",
         "operationId": "createVendors",
@@ -9068,7 +11780,9 @@
             "application/json": {
               "schema": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/SaveVendor" }
+                "items": {
+                  "$ref": "#/components/schemas/SaveVendor"
+                }
               }
             }
           },
@@ -9106,7 +11820,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9114,7 +11830,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -9123,7 +11841,9 @@
     },
     "/vendors/{vendorID}": {
       "get": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Retrieve a vendor",
         "description": "Retrieves a specific vendor.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Read</code>\n",
         "operationId": "getVendor",
@@ -9133,14 +11853,20 @@
             "in": "path",
             "description": "Vendor ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": true }
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -9148,7 +11874,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Vendor" }
+                "schema": {
+                  "$ref": "#/components/schemas/Vendor"
+                }
               }
             }
           },
@@ -9156,7 +11884,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9164,7 +11894,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9172,17 +11904,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/vendors/{vendorID}/account": {
       "get": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Retrieve vendor GL account (BETA)",
         "description": "<p class=\"betaWarning\"><b>Note: </b>This operation is still in beta and might be subject to breaking changes. Production integrations should be avoided at this stage.</p>\nRetrieves the default general ledger account of a vendor.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Read</code>\n",
         "operationId": "getVendorAccount",
@@ -9192,7 +11930,10 @@
             "in": "path",
             "description": "Vendor ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -9200,7 +11941,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Account" }
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
               }
             }
           },
@@ -9208,7 +11951,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9216,7 +11961,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9224,17 +11971,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/vendors/{vendorID}/conversations": {
       "get": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Retrieve all vendor conversations",
         "description": "Retrieves all the conversations of a vendor.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getVendorConversations",
@@ -9244,42 +11997,60 @@
             "in": "path",
             "description": "Vendor ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "type",
@@ -9288,7 +12059,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["MANAGEMENT_TEAM", "OWNER", "TENANT"]
+              "enum": [
+                "MANAGEMENT_TEAM",
+                "OWNER",
+                "TENANT"
+              ]
             }
           }
         ],
@@ -9298,14 +12073,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Conversation" }
+                  "items": {
+                    "$ref": "#/components/schemas/Conversation"
+                  }
                 }
               }
             }
@@ -9314,7 +12094,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9322,7 +12104,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9330,17 +12114,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/vendors/{vendorID}/conversations/{conversationID}": {
       "get": {
-        "tags": ["Vendors"],
+        "tags": [
+          "Vendors"
+        ],
         "summary": "Retrieve a vendor conversation",
         "description": "Retrieves a specific vendor conversation.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">VENDORS</span> - <code>Read</code>\n",
         "operationId": "getVendorConversation",
@@ -9350,14 +12140,20 @@
             "in": "path",
             "description": "Vendor ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "conversationID",
             "in": "path",
             "description": "Conversation ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -9365,7 +12161,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Conversation" }
+                "schema": {
+                  "$ref": "#/components/schemas/Conversation"
+                }
               }
             }
           },
@@ -9373,7 +12171,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9381,7 +12181,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9389,17 +12191,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/workorders": {
       "get": {
-        "tags": ["Work orders"],
+        "tags": [
+          "Work orders"
+        ],
         "summary": "Retrieve all work orders",
         "description": "Retrieves a list of work orders.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">WORK ORDERS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>number</code>, <code>type</code>, <code>lastmodifieddatetime</code>, <code>status</code>, <code>id</code>",
         "operationId": "getWorkOrders",
@@ -9409,91 +12217,132 @@
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "portfolioID",
             "in": "query",
             "description": "Filters results to prospects associated with a specific portfolio.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "buildingID",
             "in": "query",
             "description": "Filters results to prospects associated with a specific building.",
             "required": false,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "status",
             "in": "query",
             "description": "Filters results to work orders with a specific status.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "type",
             "in": "query",
             "description": "Filters results to work orders with a specific type.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "priority",
             "in": "query",
             "description": "Filters results to work orders with a specific priority.",
             "required": false,
-            "schema": { "type": "string", "enum": ["HIGH", "MEDIUM", "LOW"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "HIGH",
+                "MEDIUM",
+                "LOW"
+              ]
+            }
           },
           {
             "name": "completedDateStart",
             "in": "query",
             "description": "Filters results to any payment with a date on or after to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "completedDateEnd",
             "in": "query",
             "description": "Filters results to any payment with a date on or prior to the date specified.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": false }
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
@@ -9502,14 +12351,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/WorkOrder" }
+                  "items": {
+                    "$ref": "#/components/schemas/WorkOrder"
+                  }
                 }
               }
             }
@@ -9518,7 +12372,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9526,7 +12382,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9534,21 +12392,27 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
         }
       },
       "post": {
-        "tags": ["Work orders"],
+        "tags": [
+          "Work orders"
+        ],
         "summary": "Create a work order (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates a work order.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">WORK ORDERS</span> - <code>Write</code>\n",
         "operationId": "createWorkOrder",
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SaveWorkOrder" }
+              "schema": {
+                "$ref": "#/components/schemas/SaveWorkOrder"
+              }
             }
           },
           "description": "saveWorkOrder",
@@ -9559,7 +12423,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/WorkOrder" }
+                "schema": {
+                  "$ref": "#/components/schemas/WorkOrder"
+                }
               }
             }
           },
@@ -9567,7 +12433,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9575,7 +12443,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9583,7 +12453,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -9592,7 +12464,9 @@
     },
     "/workorders/bulk": {
       "post": {
-        "tags": ["Work orders"],
+        "tags": [
+          "Work orders"
+        ],
         "summary": "Create work orders in bulk (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreates word orders in bulk.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">WORK ORDERS</span> - <code>Write</code>\n",
         "operationId": "createWorkOrders",
@@ -9601,7 +12475,9 @@
             "application/json": {
               "schema": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/SaveWorkOrder" }
+                "items": {
+                  "$ref": "#/components/schemas/SaveWorkOrder"
+                }
               }
             }
           },
@@ -9639,7 +12515,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9647,7 +12525,9 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -9656,7 +12536,9 @@
     },
     "/workorders/{workOrderID}": {
       "delete": {
-        "tags": ["Work orders"],
+        "tags": [
+          "Work orders"
+        ],
         "summary": "Delete a Work Order (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDelete a Work Order.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">WORK ORDERS</span> - <code>Delete</code>\n",
         "operationId": "deleteWorkOrder",
@@ -9666,7 +12548,10 @@
             "in": "path",
             "description": "Work Order ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -9674,7 +12559,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -9682,7 +12569,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9690,7 +12579,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9698,17 +12589,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/workorders/{workOrderID}/tasks/{taskID}": {
       "get": {
-        "tags": ["Work orders"],
+        "tags": [
+          "Work orders"
+        ],
         "summary": "Retrieve a work order task",
         "description": "Retrieves a specific work order task.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">WORK ORDERS</span> - <code>Read</code>\n",
         "operationId": "getWorkOrderTask",
@@ -9718,14 +12615,20 @@
             "in": "path",
             "description": "Work Order ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "taskID",
             "in": "path",
             "description": "Task ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -9735,7 +12638,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Task" }
+                  "items": {
+                    "$ref": "#/components/schemas/Task"
+                  }
                 }
               }
             }
@@ -9744,7 +12649,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9752,7 +12659,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9760,15 +12669,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "delete": {
-        "tags": ["Work orders"],
+        "tags": [
+          "Work orders"
+        ],
         "summary": "Delete a work order task (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nDeletes a specific work order task.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">WORK ORDERS</span> - <code>Delete</code>\n",
         "operationId": "deleteWorkOrderTask",
@@ -9778,14 +12693,20 @@
             "in": "path",
             "description": "Work Order ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "taskID",
             "in": "path",
             "description": "Task ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "responses": {
@@ -9793,7 +12714,9 @@
             "description": "No Content",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ResponseEntity" }
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseEntity"
+                }
               }
             }
           },
@@ -9801,7 +12724,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9809,7 +12734,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9817,17 +12744,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/workorders/{workOrderId}": {
       "get": {
-        "tags": ["Work orders"],
+        "tags": [
+          "Work orders"
+        ],
         "summary": "Retrieve a work order",
         "description": "Retrieves a specific work order.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">WORK ORDERS</span> - <code>Read</code>\n",
         "operationId": "getWorkOrder",
@@ -9837,14 +12770,20 @@
             "in": "path",
             "description": "Work Order ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "includeCustomFields",
             "in": "query",
             "description": "includeCustomFields",
             "required": false,
-            "schema": { "type": "boolean", "default": true }
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
           }
         ],
         "responses": {
@@ -9852,7 +12791,9 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/WorkOrder" }
+                "schema": {
+                  "$ref": "#/components/schemas/WorkOrder"
+                }
               }
             }
           },
@@ -9860,7 +12801,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9868,7 +12811,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9876,17 +12821,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/workorders/{workOrderId}/tasks": {
       "get": {
-        "tags": ["Work orders"],
+        "tags": [
+          "Work orders"
+        ],
         "summary": "Retrieve all work order tasks",
         "description": "Retrieves a list of work order tasks.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">WORK ORDERS</span> - <code>Read</code>\n<br/><br/><b>Sortable by:</b> <code>createddate</code>, <code>lastmodifieddatetime</code>, <code>id</code>",
         "operationId": "getWorkOrderTasks",
@@ -9896,56 +12847,79 @@
             "in": "path",
             "description": "Work Order ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "description": "`offset` indicates the position of the first record to return. The offset is zero-based and the default is 0.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32" }
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "`limit` indicates the maximum number of results to be returned in the response. `limit` can range between 1 and 500 and the default is 100.",
             "required": false,
-            "schema": { "type": "integer", "format": "int32", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
           },
           {
             "name": "lastModifiedDateTimeStart",
             "in": "query",
             "description": "Filters results to any item modified on or after the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "lastModifiedDateTimeEnd",
             "in": "query",
             "description": "Filters results to any item modified on or prior to the date time specified. ",
             "required": false,
-            "schema": { "type": "string", "format": "date-time" }
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
           },
           {
             "name": "orderby",
             "in": "query",
             "description": "Indicates the field(s) and direction to sort the results in the response.",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "dueDate",
             "in": "query",
             "description": "Filters results by due day.",
             "required": false,
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "completed",
             "in": "query",
             "description": "Filters results by task status.",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -9954,14 +12928,19 @@
             "headers": {
               "X-Total-Count": {
                 "description": "The total resultset count",
-                "schema": { "type": "integer", "format": "int64" }
+                "schema": {
+                  "type": "integer",
+                  "format": "int64"
+                }
               }
             },
             "content": {
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Task" }
+                  "items": {
+                    "$ref": "#/components/schemas/Task"
+                  }
                 }
               }
             }
@@ -9970,7 +12949,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9978,7 +12959,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -9986,15 +12969,21 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       },
       "post": {
-        "tags": ["Work orders"],
+        "tags": [
+          "Work orders"
+        ],
         "summary": "Create a task to workOrder (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nCreate a task to an workOrder.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">WORK ORDERS</span> - <code>Write</code>\n",
         "operationId": "createWorkOrderTask",
@@ -10004,7 +12993,10 @@
             "in": "path",
             "description": "Work Order ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "requestBody": {
@@ -10015,7 +13007,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Task" }
+                "schema": {
+                  "$ref": "#/components/schemas/Task"
+                }
               }
             }
           },
@@ -10023,7 +13017,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -10031,7 +13027,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -10039,17 +13037,23 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     },
     "/workorders/{workOrderId}/tasks/{taskId}": {
       "put": {
-        "tags": ["Work orders"],
+        "tags": [
+          "Work orders"
+        ],
         "summary": "Update a task in workOrder (BETA)",
         "description": "<p class=\"betaError\"><b>Note: </b>Write access is only available to customers who have opted in to our beta program. Please reach out to support if you'd like to be included.</p>\nUpdate an existing workOrder task.<br/><br/><b>Required permission:</b><br/><span class=\"permissionBlock\">WORK ORDERS</span> - <code>Write</code>\n",
         "operationId": "updateWorkOrderTask",
@@ -10059,14 +13063,20 @@
             "in": "path",
             "description": "Work Order ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           {
             "name": "taskId",
             "in": "path",
             "description": "Task ID",
             "required": true,
-            "schema": { "type": "integer", "format": "int64" }
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         ],
         "requestBody": {
@@ -10077,7 +13087,9 @@
             "description": "Created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Task" }
+                "schema": {
+                  "$ref": "#/components/schemas/Task"
+                }
               }
             }
           },
@@ -10085,7 +13097,9 @@
             "description": "Unable to process the request due to malformed request syntax or invalid parameters.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -10093,7 +13107,9 @@
             "description": "The API key couldn't be authorized.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -10101,22 +13117,32 @@
             "description": "The supplied credentials don't have permissions to access the resources.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
-          "404": { "description": "Entity not found." }
+          "404": {
+            "description": "Entity not found."
+          }
         }
       }
     }
   },
-  "servers": [{ "url": "https://api.propertyware.com/pw/api/rest/v1" }],
+  "servers": [
+    {
+      "url": "https://api.propertyware.com/pw/api/rest/v1"
+    }
+  ],
   "components": {
     "requestBodies": {
       "SaveBill": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveBill" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveBill"
+            }
           }
         },
         "description": "saveBill",
@@ -10125,7 +13151,9 @@
       "SaveUnit": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveUnit" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveUnit"
+            }
           }
         },
         "description": "saveUnit",
@@ -10134,7 +13162,9 @@
       "SaveContact": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveContact" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveContact"
+            }
           }
         },
         "description": "saveContact",
@@ -10143,7 +13173,9 @@
       "SaveCharge": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveCharge" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveCharge"
+            }
           }
         },
         "description": "saveCharge",
@@ -10152,7 +13184,9 @@
       "SaveCredit": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveCredit" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveCredit"
+            }
           }
         },
         "description": "saveCredit",
@@ -10161,7 +13195,9 @@
       "SaveConversation": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveConversation" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveConversation"
+            }
           }
         },
         "description": "saveConversation",
@@ -10170,7 +13206,9 @@
       "SavePortfolio": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SavePortfolio" }
+            "schema": {
+              "$ref": "#/components/schemas/SavePortfolio"
+            }
           }
         },
         "description": "savePortfolio",
@@ -10179,7 +13217,9 @@
       "SaveAccount": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveAccount" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveAccount"
+            }
           }
         },
         "description": "saveAccount",
@@ -10188,7 +13228,9 @@
       "SaveOwnerDraw": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveOwnerDraw" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveOwnerDraw"
+            }
           }
         },
         "description": "saveOwnerDraw",
@@ -10197,7 +13239,9 @@
       "SaveBillPayment": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveBillPayment" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveBillPayment"
+            }
           }
         },
         "description": "saveBillPayment",
@@ -10206,7 +13250,9 @@
       "SaveCheck": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveCheck" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveCheck"
+            }
           }
         },
         "description": "saveCheck",
@@ -10215,7 +13261,9 @@
       "SaveBuilding": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveBuilding" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveBuilding"
+            }
           }
         },
         "description": "saveBuilding",
@@ -10224,7 +13272,9 @@
       "SaveAdjustment": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveAdjustment" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveAdjustment"
+            }
           }
         },
         "description": "saveAdjustment",
@@ -10233,7 +13283,9 @@
       "SaveDiscount": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveDiscount" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveDiscount"
+            }
           }
         },
         "description": "saveDiscount",
@@ -10242,7 +13294,9 @@
       "SavePayment": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SavePayment" }
+            "schema": {
+              "$ref": "#/components/schemas/SavePayment"
+            }
           }
         },
         "description": "savePayment",
@@ -10251,7 +13305,9 @@
       "SaveRefund": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveRefund" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveRefund"
+            }
           }
         },
         "description": "saveRefund",
@@ -10260,7 +13316,9 @@
       "SaveWorkOrderTask": {
         "content": {
           "application/json": {
-            "schema": { "$ref": "#/components/schemas/SaveWorkOrderTask" }
+            "schema": {
+              "$ref": "#/components/schemas/SaveWorkOrderTask"
+            }
           }
         },
         "description": "saveWorkOrderTask",
@@ -10383,16 +13441,31 @@
             "type": "string",
             "description": "Company where the contact is employed."
           },
-          "email": { "type": "string", "description": "E-mail address." },
-          "firstName": { "type": "string", "description": "First name." },
-          "homePhone": { "type": "string", "description": "Home phone." },
+          "email": {
+            "type": "string",
+            "description": "E-mail address."
+          },
+          "firstName": {
+            "type": "string",
+            "description": "First name."
+          },
+          "homePhone": {
+            "type": "string",
+            "description": "Home phone."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
             "description": "Unique identifier."
           },
-          "lastName": { "type": "string", "description": "Last name." },
-          "mobilePhone": { "type": "string", "description": "Mobile phone." },
+          "lastName": {
+            "type": "string",
+            "description": "Last name."
+          },
+          "mobilePhone": {
+            "type": "string",
+            "description": "Mobile phone."
+          },
           "namedOnLease": {
             "type": "boolean",
             "example": false,
@@ -10403,14 +13476,20 @@
             "example": false,
             "description": "Indicates if contact is primary contact of the lease."
           },
-          "workPhone": { "type": "string", "description": "Work phone." }
+          "workPhone": {
+            "type": "string",
+            "description": "Work phone."
+          }
         },
         "description": "Contact of the lease"
       },
       "GLItem": {
         "type": "object",
         "properties": {
-          "comment": { "type": "string", "description": "Comments." },
+          "comment": {
+            "type": "string",
+            "description": "Comments."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -10422,7 +13501,9 @@
           },
           "glentries": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Entry" }
+            "items": {
+              "$ref": "#/components/schemas/Entry"
+            }
           },
           "id": {
             "type": "integer",
@@ -10477,7 +13558,10 @@
             "format": "int64",
             "description": "Unique identifier."
           },
-          "name": { "type": "string", "description": "Name of the clause." }
+          "name": {
+            "type": "string",
+            "description": "Name of the clause."
+          }
         }
       },
       "CampaignSource": {
@@ -10487,7 +13571,9 @@
             "type": "string",
             "description": "Call tracking group id."
           },
-          "default": { "type": "boolean" },
+          "default": {
+            "type": "boolean"
+          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -10516,7 +13602,10 @@
             "format": "date-time",
             "description": "Date and time the record was created. (Timezone: UTC)"
           },
-          "description": { "type": "string", "description": "Description." },
+          "description": {
+            "type": "string",
+            "description": "Description."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -10531,20 +13620,36 @@
             "format": "date-time",
             "description": "Date and time the record was last modified. (Timezone: UTC)"
           },
-          "name": { "type": "string", "description": "Bank deposit name." },
-          "status": { "type": "string", "description": "Status." }
+          "name": {
+            "type": "string",
+            "description": "Bank deposit name."
+          },
+          "status": {
+            "type": "string",
+            "description": "Status."
+          }
         },
         "description": "Bank Deposit"
       },
       "SaveConversation": {
         "type": "object",
-        "required": ["text", "type"],
+        "required": [
+          "text",
+          "type"
+        ],
         "properties": {
-          "text": { "type": "string", "description": "Comment text." },
+          "text": {
+            "type": "string",
+            "description": "Comment text."
+          },
           "type": {
             "type": "string",
             "description": "Conversation type.",
-            "enum": ["MANAGEMENT_TEAM", "OWNER", "TENANT"]
+            "enum": [
+              "MANAGEMENT_TEAM",
+              "OWNER",
+              "TENANT"
+            ]
           }
         },
         "description": "Conversation for Request"
@@ -10552,11 +13657,21 @@
       "CustomFieldDefinition": {
         "type": "object",
         "properties": {
-          "dataType": { "type": "string" },
-          "defaultValue": { "type": "string" },
-          "fieldName": { "type": "string" },
-          "groupName": { "type": "string" },
-          "requiredField": { "type": "string" }
+          "dataType": {
+            "type": "string"
+          },
+          "defaultValue": {
+            "type": "string"
+          },
+          "fieldName": {
+            "type": "string"
+          },
+          "groupName": {
+            "type": "string"
+          },
+          "requiredField": {
+            "type": "string"
+          }
         },
         "description": "Custom field definition."
       },
@@ -10597,8 +13712,13 @@
             "type": "string",
             "description": "Search phrase for call tracking."
           },
-          "campaignSource": { "$ref": "#/components/schemas/CampaignSource" },
-          "code": { "type": "string", "description": "Code of the campaign." },
+          "campaignSource": {
+            "$ref": "#/components/schemas/CampaignSource"
+          },
+          "code": {
+            "type": "string",
+            "description": "Code of the campaign."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -10611,7 +13731,9 @@
           "customFields": {
             "type": "array",
             "description": "Custom fields.",
-            "items": { "$ref": "#/components/schemas/CustomField" }
+            "items": {
+              "$ref": "#/components/schemas/CustomField"
+            }
           },
           "description": {
             "type": "string",
@@ -10636,7 +13758,10 @@
             "format": "date-time",
             "description": "Date and time the record was last modified. (Timezone: UTC)"
           },
-          "name": { "type": "string", "description": "Name of the campaign." },
+          "name": {
+            "type": "string",
+            "description": "Name of the campaign."
+          },
           "startDate": {
             "type": "string",
             "format": "date",
@@ -10655,7 +13780,9 @@
       },
       "UpdateDocument": {
         "type": "object",
-        "required": ["fileName"],
+        "required": [
+          "fileName"
+        ],
         "properties": {
           "description": {
             "type": "string",
@@ -10730,14 +13857,22 @@
       },
       "SaveDiscount": {
         "type": "object",
-        "required": ["amount", "date", "discountAccountID", "leaseID"],
+        "required": [
+          "amount",
+          "date",
+          "discountAccountID",
+          "leaseID"
+        ],
         "properties": {
           "amount": {
             "type": "number",
             "format": "double",
             "description": "Amount, should be negative."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "date": {
             "type": "string",
             "format": "date",
@@ -10753,13 +13888,19 @@
             "format": "int64",
             "description": "Id of the lease associated with this discount."
           },
-          "refNo": { "type": "string", "description": "Ref No." }
+          "refNo": {
+            "type": "string",
+            "description": "Ref No."
+          }
         },
         "description": "Discount for Request"
       },
       "SaveBillSplit": {
         "type": "object",
-        "required": ["amount", "portfolioID"],
+        "required": [
+          "amount",
+          "portfolioID"
+        ],
         "properties": {
           "amount": {
             "type": "number",
@@ -10776,7 +13917,10 @@
             "format": "int64",
             "description": "Location Building ID."
           },
-          "comments": { "type": "string", "description": "Split comments." },
+          "comments": {
+            "type": "string",
+            "description": "Split comments."
+          },
           "glAccountID": {
             "type": "integer",
             "format": "int64",
@@ -10827,7 +13971,9 @@
             "minLength": 1,
             "maxLength": 12
           },
-          "address": { "$ref": "#/components/schemas/SaveAddress" },
+          "address": {
+            "$ref": "#/components/schemas/SaveAddress"
+          },
           "availableDate": {
             "type": "string",
             "format": "date",
@@ -10841,7 +13987,10 @@
           "category": {
             "type": "string",
             "description": "Unit Category.",
-            "enum": ["RESIDENTIAL", "COMMERCIAL"]
+            "enum": [
+              "RESIDENTIAL",
+              "COMMERCIAL"
+            ]
           },
           "county": {
             "type": "string",
@@ -10857,9 +14006,16 @@
             "type": "integer",
             "format": "int32",
             "description": "Floor number.",
-            "enum": [0, 1, 2]
+            "enum": [
+              0,
+              1,
+              2
+            ]
           },
-          "name": { "type": "string", "description": "Name of the unit." },
+          "name": {
+            "type": "string",
+            "description": "Name of the unit."
+          },
           "neighborhood": {
             "type": "string",
             "description": "Neighborhood.",
@@ -10871,8 +14027,26 @@
             "format": "double",
             "description": "Number of bathrooms in the unit.",
             "enum": [
-              0, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5,
-              9, 9.5, 10
+              0,
+              1,
+              1.5,
+              2,
+              2.5,
+              3,
+              3.5,
+              4,
+              4.5,
+              5,
+              5.5,
+              6,
+              6.5,
+              7,
+              7.5,
+              8,
+              8.5,
+              9,
+              9.5,
+              10
             ]
           },
           "numberBedrooms": {
@@ -10974,8 +14148,13 @@
             "format": "double",
             "description": "Debit amount."
           },
-          "glaccountCode": { "type": "string" },
-          "glaccountID": { "type": "integer", "format": "int64" },
+          "glaccountCode": {
+            "type": "string"
+          },
+          "glaccountID": {
+            "type": "integer",
+            "format": "int64"
+          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -10996,7 +14175,10 @@
       },
       "SavePortfolio": {
         "type": "object",
-        "required": ["abbreviation", "name"],
+        "required": [
+          "abbreviation",
+          "name"
+        ],
         "properties": {
           "abbreviation": {
             "type": "string",
@@ -11005,7 +14187,11 @@
           "cashAccrual": {
             "type": "string",
             "description": "Cash or accrual accounting basis.",
-            "enum": ["COMPANY_DEFAULT", "CASH", "ACCRUAL"]
+            "enum": [
+              "COMPANY_DEFAULT",
+              "CASH",
+              "ACCRUAL"
+            ]
           },
           "closingDate": {
             "type": "string",
@@ -11035,13 +14221,23 @@
           "maintenanceSpendingLimitTime": {
             "type": "string",
             "description": "Monthly or Yearly Maintenance Spending Limit Time set for the portfolio for maintenance bills created by work orders.",
-            "enum": ["NO_LIMIT", "DOLLAR_PER_MONTH", "DOLLAR_PER_YEAR"]
+            "enum": [
+              "NO_LIMIT",
+              "DOLLAR_PER_MONTH",
+              "DOLLAR_PER_YEAR"
+            ]
           },
-          "name": { "type": "string", "description": "Name of the portfolio." },
+          "name": {
+            "type": "string",
+            "description": "Name of the portfolio."
+          },
           "ownerIds": {
             "type": "array",
             "description": "Portfolio owner Ids",
-            "items": { "type": "integer", "format": "int64" }
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           "ownerStatementReportID": {
             "type": "integer",
@@ -11051,7 +14247,9 @@
           "owners": {
             "type": "array",
             "description": "Portfolio owners.",
-            "items": { "$ref": "#/components/schemas/SaveOwner" }
+            "items": {
+              "$ref": "#/components/schemas/SaveOwner"
+            }
           },
           "stickyNote": {
             "type": "string",
@@ -11082,7 +14280,10 @@
             "format": "int64",
             "description": "Id of the building associated with the prospect."
           },
-          "cityDesired": { "type": "string", "description": "Desired city." },
+          "cityDesired": {
+            "type": "string",
+            "description": "Desired city."
+          },
           "comments": {
             "type": "string",
             "description": "Indicates if the prospect has any comments."
@@ -11090,7 +14291,9 @@
           "contacts": {
             "type": "array",
             "description": "Contacts of the prospect",
-            "items": { "$ref": "#/components/schemas/ProspectContact" }
+            "items": {
+              "$ref": "#/components/schemas/ProspectContact"
+            }
           },
           "createdBy": {
             "type": "string",
@@ -11113,7 +14316,9 @@
           "customFields": {
             "type": "array",
             "description": "Custom fields.",
-            "items": { "$ref": "#/components/schemas/CustomField" }
+            "items": {
+              "$ref": "#/components/schemas/CustomField"
+            }
           },
           "hasPets": {
             "type": "boolean",
@@ -11168,8 +14373,14 @@
             "format": "int32",
             "description": "Number of pets."
           },
-          "petType": { "type": "string", "description": "Pet type." },
-          "petWeights": { "type": "string", "description": "Pet weights." },
+          "petType": {
+            "type": "string",
+            "description": "Pet type."
+          },
+          "petWeights": {
+            "type": "string",
+            "description": "Pet weights."
+          },
           "portfolioID": {
             "type": "integer",
             "format": "int64",
@@ -11246,19 +14457,34 @@
             "format": "double",
             "description": "Confirmed lease security deposit."
           },
-          "source": { "type": "string", "description": "Prospect source." },
-          "stateDesired": { "type": "string", "description": "Desired state." },
-          "status": { "type": "string", "description": "Status." },
+          "source": {
+            "type": "string",
+            "description": "Prospect source."
+          },
+          "stateDesired": {
+            "type": "string",
+            "description": "Desired state."
+          },
+          "status": {
+            "type": "string",
+            "description": "Status."
+          },
           "timeAtCurrentResidence": {
             "type": "string",
             "description": "Time the prospect is living at the current residence."
           },
-          "type": { "type": "string", "description": "Prospect type." },
+          "type": {
+            "type": "string",
+            "description": "Prospect type."
+          },
           "typeOfInquiry": {
             "type": "string",
             "description": "Type of inquiry made by the prospect."
           },
-          "unitDesired": { "type": "string", "description": "Desired unit." },
+          "unitDesired": {
+            "type": "string",
+            "description": "Desired unit."
+          },
           "unitID": {
             "type": "integer",
             "format": "int64",
@@ -11268,24 +14494,45 @@
             "type": "string",
             "description": "Desired unit type."
           },
-          "zipDesired": { "type": "string", "description": "Desired zip code." }
+          "zipDesired": {
+            "type": "string",
+            "description": "Desired zip code."
+          }
         },
         "description": "Prospect"
       },
       "ProspectContact": {
         "type": "object",
         "properties": {
-          "email": { "type": "string", "description": "E-mail address." },
-          "firstName": { "type": "string", "description": "First name." },
-          "homePhone": { "type": "string", "description": "Home phone." },
+          "email": {
+            "type": "string",
+            "description": "E-mail address."
+          },
+          "firstName": {
+            "type": "string",
+            "description": "First name."
+          },
+          "homePhone": {
+            "type": "string",
+            "description": "Home phone."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
             "description": "Unique identifier."
           },
-          "lastName": { "type": "string", "description": "Last name." },
-          "mobilePhone": { "type": "string", "description": "Mobile phone." },
-          "workPhone": { "type": "string", "description": "Work phone." }
+          "lastName": {
+            "type": "string",
+            "description": "Last name."
+          },
+          "mobilePhone": {
+            "type": "string",
+            "description": "Mobile phone."
+          },
+          "workPhone": {
+            "type": "string",
+            "description": "Work phone."
+          }
         },
         "description": "Contact of the prospect"
       },
@@ -11305,7 +14552,9 @@
           "billSplits": {
             "type": "array",
             "description": "List of bill splits.",
-            "items": { "$ref": "#/components/schemas/SplitPaid" }
+            "items": {
+              "$ref": "#/components/schemas/SplitPaid"
+            }
           },
           "id": {
             "type": "integer",
@@ -11320,7 +14569,9 @@
           "billSplits": {
             "type": "array",
             "description": "Bill splits list.",
-            "items": { "$ref": "#/components/schemas/SplitPay" }
+            "items": {
+              "$ref": "#/components/schemas/SplitPay"
+            }
           },
           "id": {
             "type": "integer",
@@ -11345,7 +14596,10 @@
             "format": "double",
             "description": "Property base rent."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "endDate": {
             "type": "string",
             "format": "date",
@@ -11398,13 +14652,18 @@
             "type": "string",
             "description": "Public assistance program. Allowed values are 'None', 'Section 8', 'SCRIE', 'Rent Control', 'EDEN INC. - Shelter Care Plus', 'CLC', 'DHAP', 'FEMA', 'Harris County' etc. "
           },
-          "rentAutoCharge": { "$ref": "#/components/schemas/SaveAutoCharge" },
+          "rentAutoCharge": {
+            "$ref": "#/components/schemas/SaveAutoCharge"
+          },
           "scheduleMoveOutDate": {
             "type": "string",
             "format": "date",
             "description": "Scheduled move out date."
           },
-          "searchTag": { "type": "string", "description": "Search tag." },
+          "searchTag": {
+            "type": "string",
+            "description": "Search tag."
+          },
           "secDepAmount": {
             "type": "number",
             "format": "double",
@@ -11432,7 +14691,10 @@
           "tenantIDs": {
             "type": "array",
             "description": "List of tenant IDs.",
-            "items": { "type": "integer", "format": "int64" }
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
           },
           "unitID": {
             "type": "integer",
@@ -11465,7 +14727,10 @@
             "format": "int64",
             "description": "Id of the building associated with this line item."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -11545,11 +14810,16 @@
             "type": "string",
             "description": "Abbreviation of Building."
           },
-          "address": { "$ref": "#/components/schemas/SaveAddress" },
+          "address": {
+            "$ref": "#/components/schemas/SaveAddress"
+          },
           "allocationMethod": {
             "type": "string",
             "description": "Allocation method.",
-            "enum": ["By Square Foot", "By Percent"]
+            "enum": [
+              "By Square Foot",
+              "By Percent"
+            ]
           },
           "availableDate": {
             "type": "string",
@@ -11559,7 +14829,10 @@
           "category": {
             "type": "string",
             "description": "Building category.",
-            "enum": ["RESIDENTIAL", "COMMERCIAL"]
+            "enum": [
+              "RESIDENTIAL",
+              "COMMERCIAL"
+            ]
           },
           "countUnit": {
             "type": "integer",
@@ -11593,12 +14866,18 @@
             "example": false,
             "description": "Indicates if the building is multi family or single family."
           },
-          "name": { "type": "string", "description": "Name of the building." },
+          "name": {
+            "type": "string",
+            "description": "Name of the building."
+          },
           "naming": {
             "type": "string",
             "description": "Unit naming (Unit, Suite, Space, Custom)."
           },
-          "neighborhood": { "type": "string", "description": "Neighborhood." },
+          "neighborhood": {
+            "type": "string",
+            "description": "Neighborhood."
+          },
           "numberBathrooms": {
             "type": "number",
             "format": "double",
@@ -11622,7 +14901,10 @@
             "type": "string",
             "description": "Other tenant charges."
           },
-          "parcelNumber": { "type": "string", "description": "Parcel number." },
+          "parcelNumber": {
+            "type": "string",
+            "description": "Parcel number."
+          },
           "petsAllowed": {
             "type": "boolean",
             "example": false,
@@ -11658,14 +14940,20 @@
           "publishedForRent": {
             "type": "string",
             "description": "Published for rent.",
-            "enum": ["Yes", "No"]
+            "enum": [
+              "Yes",
+              "No"
+            ]
           },
           "rentable": {
             "type": "boolean",
             "example": false,
             "description": "Indicates if the building is rentable."
           },
-          "searchTag": { "type": "string", "description": "Search tag name." },
+          "searchTag": {
+            "type": "string",
+            "description": "Search tag name."
+          },
           "shortDescription": {
             "type": "string",
             "description": "Marketing short description."
@@ -11744,8 +15032,14 @@
               "WORK_ORDER"
             ]
           },
-          "fileName": { "type": "string", "description": "File name." },
-          "fileType": { "type": "string", "description": "File type." },
+          "fileName": {
+            "type": "string",
+            "description": "File name."
+          },
+          "fileType": {
+            "type": "string",
+            "description": "File type."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -11775,7 +15069,10 @@
       "InspectionItem": {
         "type": "object",
         "properties": {
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -11794,7 +15091,11 @@
       },
       "JournalEntrySplitResponse": {
         "type": "object",
-        "required": ["creditAmount", "debitAmount", "glAccountID"],
+        "required": [
+          "creditAmount",
+          "debitAmount",
+          "glAccountID"
+        ],
         "properties": {
           "creditAmount": {
             "type": "number",
@@ -11820,7 +15121,10 @@
       },
       "SaveCheckSplit": {
         "type": "object",
-        "required": ["glAccountID", "portfolioID"],
+        "required": [
+          "glAccountID",
+          "portfolioID"
+        ],
         "properties": {
           "amount": {
             "type": "number",
@@ -11880,12 +15184,18 @@
           "assignedVendors": {
             "type": "array",
             "description": "List of vendors attached to the work order.",
-            "items": { "$ref": "#/components/schemas/BasicVendor" }
+            "items": {
+              "$ref": "#/components/schemas/BasicVendor"
+            }
           },
           "authorizeEnter": {
             "type": "string",
             "description": "Indicates if the tenant has granted your management staff access to enter his or her buildings and/or units.",
-            "enum": ["NO", "ANYTIME", "SPECIFIEDTIME"]
+            "enum": [
+              "NO",
+              "ANYTIME",
+              "SPECIFIEDTIME"
+            ]
           },
           "buildingID": {
             "type": "integer",
@@ -11922,7 +15232,9 @@
           "customFields": {
             "type": "array",
             "description": "Custom fields.",
-            "items": { "$ref": "#/components/schemas/CustomField" }
+            "items": {
+              "$ref": "#/components/schemas/CustomField"
+            }
           },
           "dateToEnter": {
             "type": "string",
@@ -11981,7 +15293,11 @@
           "priority": {
             "type": "string",
             "description": "This identifies the priority of the work order as low, medium, or high.",
-            "enum": ["HIGH", "MEDIUM", "LOW"]
+            "enum": [
+              "HIGH",
+              "MEDIUM",
+              "LOW"
+            ]
           },
           "requestedBy": {
             "type": "string",
@@ -11996,7 +15312,10 @@
             "format": "date",
             "description": "Date on which the work is scheduled to be completed."
           },
-          "searchTag": { "type": "string", "description": "Search tag name." },
+          "searchTag": {
+            "type": "string",
+            "description": "Search tag name."
+          },
           "source": {
             "type": "string",
             "description": "This identifies how the problem was reported, such as telephone, in person, email, etc."
@@ -12023,14 +15342,20 @@
       },
       "Adjustment": {
         "type": "object",
-        "required": ["amount", "date"],
+        "required": [
+          "amount",
+          "date"
+        ],
         "properties": {
           "amount": {
             "type": "number",
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -12074,13 +15399,19 @@
             "format": "int64",
             "description": "Id of the portfolio associated with this charge."
           },
-          "refNo": { "type": "string", "description": "Reference number." }
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          }
         },
         "description": "Adjustment"
       },
       "Refund": {
         "type": "object",
-        "required": ["amount", "date"],
+        "required": [
+          "amount",
+          "date"
+        ],
         "properties": {
           "amount": {
             "type": "number",
@@ -12139,7 +15470,10 @@
             "format": "int64",
             "description": "Id of the portfolio associated with the refund."
           },
-          "refNo": { "type": "string", "description": "Reference number." },
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          },
           "toBePrinted": {
             "type": "boolean",
             "example": false,
@@ -12174,7 +15508,10 @@
             "format": "date-time",
             "description": "Date and time the record was last modified. (Timezone: UTC)"
           },
-          "text": { "type": "string", "description": "Comment text." }
+          "text": {
+            "type": "string",
+            "description": "Comment text."
+          }
         },
         "description": "Comment"
       },
@@ -12183,16 +15520,26 @@
         "properties": {
           "error": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/RESTAPIError" }
+            "items": {
+              "$ref": "#/components/schemas/RESTAPIError"
+            }
           },
-          "index": { "type": "integer", "format": "int32" },
-          "success": { "type": "boolean" }
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "success": {
+            "type": "boolean"
+          }
         }
       },
       "Note": {
         "type": "object",
         "properties": {
-          "body": { "type": "string", "description": "Content of the note." },
+          "body": {
+            "type": "string",
+            "description": "Content of the note."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -12221,8 +15568,13 @@
             "format": "date-time",
             "description": "Date and time the record was last modified. (Timezone: UTC)"
           },
-          "private": { "type": "boolean" },
-          "subject": { "type": "string", "description": "Subject." }
+          "private": {
+            "type": "boolean"
+          },
+          "subject": {
+            "type": "string",
+            "description": "Subject."
+          }
         }
       },
       "SplitPay": {
@@ -12243,7 +15595,10 @@
       "AutoJournalEntry": {
         "type": "object",
         "properties": {
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -12253,8 +15608,14 @@
             "format": "date-time",
             "description": "Date and time the record was created. (Timezone: UTC)"
           },
-          "credit": { "type": "string", "description": "Credit amount." },
-          "debit": { "type": "string", "description": "Debit amount." },
+          "credit": {
+            "type": "string",
+            "description": "Credit amount."
+          },
+          "debit": {
+            "type": "string",
+            "description": "Debit amount."
+          },
           "endDate": {
             "type": "string",
             "format": "date",
@@ -12263,7 +15624,12 @@
           "frequency": {
             "type": "string",
             "description": "Frequency.",
-            "enum": ["WEEKLY", "MONTHLY", "YEARLY", "MANUALLY"]
+            "enum": [
+              "WEEKLY",
+              "MONTHLY",
+              "YEARLY",
+              "MANUALLY"
+            ]
           },
           "id": {
             "type": "integer",
@@ -12293,7 +15659,10 @@
             "format": "date",
             "description": "Next post date."
           },
-          "payDay": { "type": "string", "description": "Pay day." },
+          "payDay": {
+            "type": "string",
+            "description": "Pay day."
+          },
           "startDate": {
             "type": "string",
             "format": "date",
@@ -12349,14 +15718,22 @@
       },
       "SaveCharge": {
         "type": "object",
-        "required": ["amount", "date", "glAccountID", "leaseID"],
+        "required": [
+          "amount",
+          "date",
+          "glAccountID",
+          "leaseID"
+        ],
         "properties": {
           "amount": {
             "type": "number",
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "date": {
             "type": "string",
             "format": "date",
@@ -12372,7 +15749,10 @@
             "format": "int64",
             "description": "Lease ID."
           },
-          "refNo": { "type": "string", "description": "Charge reference No." }
+          "refNo": {
+            "type": "string",
+            "description": "Charge reference No."
+          }
         },
         "description": "Charge for Request"
       },
@@ -12419,7 +15799,10 @@
       },
       "Charge": {
         "type": "object",
-        "required": ["frequency", "startDate"],
+        "required": [
+          "frequency",
+          "startDate"
+        ],
         "properties": {
           "account": {
             "type": "string",
@@ -12605,27 +15988,40 @@
       },
       "SaveComment": {
         "type": "object",
-        "required": ["text"],
+        "required": [
+          "text"
+        ],
         "properties": {
-          "text": { "type": "string", "description": "Comment text." }
+          "text": {
+            "type": "string",
+            "description": "Comment text."
+          }
         },
         "description": "Comment for Request"
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "errorCode": { "type": "string" },
+          "errorCode": {
+            "type": "string"
+          },
           "errors": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/RESTAPIError" }
+            "items": {
+              "$ref": "#/components/schemas/RESTAPIError"
+            }
           },
-          "userMessage": { "type": "string" }
+          "userMessage": {
+            "type": "string"
+          }
         }
       },
       "ResponseEntity": {
         "type": "object",
         "properties": {
-          "body": { "type": "object" },
+          "body": {
+            "type": "object"
+          },
           "statusCode": {
             "type": "string",
             "enum": [
@@ -12698,7 +16094,12 @@
       },
       "SaveAccount": {
         "type": "object",
-        "required": ["accountNumber", "accountType", "code", "description"],
+        "required": [
+          "accountNumber",
+          "accountType",
+          "code",
+          "description"
+        ],
         "properties": {
           "accountNumber": {
             "type": "string",
@@ -12714,18 +16115,38 @@
             "example": false,
             "description": "Indicates if prepayments should be auto applied."
           },
-          "bank": { "$ref": "#/components/schemas/Bank" },
-          "code": { "type": "string", "description": "Account code." },
-          "creditCard": { "$ref": "#/components/schemas/CreditCardAccount" },
-          "currentAsset": { "$ref": "#/components/schemas/CurrentAsset" },
+          "bank": {
+            "$ref": "#/components/schemas/Bank"
+          },
+          "code": {
+            "type": "string",
+            "description": "Account code."
+          },
+          "creditCard": {
+            "$ref": "#/components/schemas/CreditCardAccount"
+          },
+          "currentAsset": {
+            "$ref": "#/components/schemas/CurrentAsset"
+          },
           "currentLiability": {
             "$ref": "#/components/schemas/CurrentLiability"
           },
-          "description": { "type": "string", "description": "Description." },
-          "equity": { "$ref": "#/components/schemas/Equity" },
-          "expense": { "$ref": "#/components/schemas/Expense" },
-          "income": { "$ref": "#/components/schemas/Income" },
-          "nonCurrentAsset": { "$ref": "#/components/schemas/NonCurrentAsset" },
+          "description": {
+            "type": "string",
+            "description": "Description."
+          },
+          "equity": {
+            "$ref": "#/components/schemas/Equity"
+          },
+          "expense": {
+            "$ref": "#/components/schemas/Expense"
+          },
+          "income": {
+            "$ref": "#/components/schemas/Income"
+          },
+          "nonCurrentAsset": {
+            "$ref": "#/components/schemas/NonCurrentAsset"
+          },
           "nonCurrentLiability": {
             "$ref": "#/components/schemas/NonCurrentLiability"
           },
@@ -12751,12 +16172,18 @@
       "Account": {
         "type": "object",
         "properties": {
-          "accountCode": { "type": "string", "description": "Account code." },
+          "accountCode": {
+            "type": "string",
+            "description": "Account code."
+          },
           "accountNumber": {
             "type": "string",
             "description": "Account number."
           },
-          "accountType": { "type": "string", "description": "Account type." },
+          "accountType": {
+            "type": "string",
+            "description": "Account type."
+          },
           "active": {
             "type": "boolean",
             "example": false,
@@ -12775,12 +16202,18 @@
             "type": "string",
             "description": "Bank account number."
           },
-          "bankAddress": { "type": "string", "description": "Bank address." },
+          "bankAddress": {
+            "type": "string",
+            "description": "Bank address."
+          },
           "bankAddress2": {
             "type": "string",
             "description": "Bank address 2."
           },
-          "bankCity": { "type": "string", "description": "Bank city." },
+          "bankCity": {
+            "type": "string",
+            "description": "Bank city."
+          },
           "bankInstitution": {
             "type": "string",
             "description": "Bank institution name."
@@ -12789,8 +16222,14 @@
             "type": "string",
             "description": "Bank account routing number."
           },
-          "bankState": { "type": "string", "description": "Bank state." },
-          "bankZip": { "type": "string", "description": "Bank zip code." },
+          "bankState": {
+            "type": "string",
+            "description": "Bank state."
+          },
+          "bankZip": {
+            "type": "string",
+            "description": "Bank zip code."
+          },
           "camRecoveryAccount": {
             "type": "boolean",
             "example": false,
@@ -12849,7 +16288,10 @@
             "example": false,
             "description": "Indicates if a late fee is applicable."
           },
-          "name": { "type": "string", "description": "Account name." },
+          "name": {
+            "type": "string",
+            "description": "Account name."
+          },
           "parentGLAccountId": {
             "type": "integer",
             "format": "int64",
@@ -12889,12 +16331,18 @@
       },
       "SaveWorkOrder": {
         "type": "object",
-        "required": ["buildingID"],
+        "required": [
+          "buildingID"
+        ],
         "properties": {
           "authorizeEnter": {
             "type": "string",
             "description": "This field indicates if the tenant has granted the maintenance staff permission to enter the unit.",
-            "enum": ["NO", "ANYTIME", "SPECIFIEDTIME"]
+            "enum": [
+              "NO",
+              "ANYTIME",
+              "SPECIFIEDTIME"
+            ]
           },
           "buildingID": {
             "type": "integer",
@@ -12937,7 +16385,11 @@
           "priority": {
             "type": "string",
             "description": "Priority of the work order.",
-            "enum": ["HIGH", "MEDIUM", "LOW"]
+            "enum": [
+              "HIGH",
+              "MEDIUM",
+              "LOW"
+            ]
           },
           "requestedBy": {
             "type": "integer",
@@ -12965,7 +16417,10 @@
           "unitIDs": {
             "type": "array",
             "description": "List of unit Ids that are attached to the building.",
-            "items": { "type": "integer", "format": "int64" }
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
           }
         },
         "description": "Work Order for Request"
@@ -12973,7 +16428,10 @@
       "BasicVendor": {
         "type": "object",
         "properties": {
-          "address": { "type": "string", "description": "Address." },
+          "address": {
+            "type": "string",
+            "description": "Address."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -12986,10 +16444,18 @@
           "customFields": {
             "type": "array",
             "description": "Custom fields.",
-            "items": { "$ref": "#/components/schemas/CustomField" }
+            "items": {
+              "$ref": "#/components/schemas/CustomField"
+            }
           },
-          "email": { "type": "string", "description": "Email address." },
-          "fax": { "type": "string", "description": "Fax number." },
+          "email": {
+            "type": "string",
+            "description": "Email address."
+          },
+          "fax": {
+            "type": "string",
+            "description": "Fax number."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -13004,19 +16470,29 @@
             "format": "date-time",
             "description": "Date and time the record was last modified. (Timezone: UTC)"
           },
-          "name": { "type": "string", "description": "Name." },
+          "name": {
+            "type": "string",
+            "description": "Name."
+          },
           "otherPhone": {
             "type": "string",
             "description": "Other phone number."
           },
-          "phone": { "type": "string", "description": "Phone number." }
+          "phone": {
+            "type": "string",
+            "description": "Phone number."
+          }
         }
       },
       "RESTAPIError": {
         "type": "object",
         "properties": {
-          "key": { "type": "string" },
-          "message": { "type": "string" }
+          "key": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       },
       "SaveOwnerDraw": {
@@ -13036,7 +16512,10 @@
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "contactID": {
             "type": "integer",
             "format": "int64",
@@ -13076,14 +16555,20 @@
       },
       "OwnerContribution": {
         "type": "object",
-        "required": ["amount", "date"],
+        "required": [
+          "amount",
+          "date"
+        ],
         "properties": {
           "amount": {
             "type": "number",
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "contactID": {
             "type": "integer",
             "format": "int64",
@@ -13144,7 +16629,8 @@
               "ECHECK",
               "NACHA",
               "RENTMONEY",
-              "PUBLIC_ASSISTANCE"
+              "PUBLIC_ASSISTANCE",
+              "PAYMENT_TYPE_NA"
             ]
           },
           "portfolioID": {
@@ -13152,7 +16638,10 @@
             "format": "int64",
             "description": "Id of the portfolio to apply the payment to."
           },
-          "refNo": { "type": "string", "description": "Reference number." }
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          }
         },
         "description": "Owner Contribution"
       },
@@ -13196,7 +16685,11 @@
       },
       "JournalEntrySplit": {
         "type": "object",
-        "required": ["creditAmount", "debitAmount", "glAccountID"],
+        "required": [
+          "creditAmount",
+          "debitAmount",
+          "glAccountID"
+        ],
         "properties": {
           "creditAmount": {
             "type": "number",
@@ -13237,9 +16730,14 @@
           "billSplits": {
             "type": "array",
             "description": "List of bill splits.",
-            "items": { "$ref": "#/components/schemas/BillSplit" }
+            "items": {
+              "$ref": "#/components/schemas/BillSplit"
+            }
           },
-          "comments": { "type": "string", "description": "Description." },
+          "comments": {
+            "type": "string",
+            "description": "Description."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -13293,8 +16791,14 @@
             "format": "date",
             "description": "Date the bill was paid."
           },
-          "refNo": { "type": "string", "description": "Reference number." },
-          "terms": { "type": "string", "description": "Bill terms." },
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          },
+          "terms": {
+            "type": "string",
+            "description": "Bill terms."
+          },
           "vendorID": {
             "type": "integer",
             "format": "int64",
@@ -13341,9 +16845,16 @@
       },
       "UpdateLeaseJournalEntry": {
         "type": "object",
-        "required": ["comments", "date", "leaseID"],
+        "required": [
+          "comments",
+          "date",
+          "leaseID"
+        ],
         "properties": {
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "date": {
             "type": "string",
             "format": "date",
@@ -13352,7 +16863,9 @@
           "journalEntrySplit": {
             "type": "array",
             "description": "Journal Entry Splits.",
-            "items": { "$ref": "#/components/schemas/JournalEntrySplit" }
+            "items": {
+              "$ref": "#/components/schemas/JournalEntrySplit"
+            }
           },
           "leaseID": {
             "type": "integer",
@@ -13369,7 +16882,9 @@
       "Contact": {
         "type": "object",
         "properties": {
-          "address": { "$ref": "#/components/schemas/Address" },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
           "allowESignature": {
             "type": "boolean",
             "example": false,
@@ -13384,8 +16899,14 @@
             "format": "date",
             "description": "Date of birth."
           },
-          "category": { "type": "string", "description": "Contact category." },
-          "comments": { "type": "string", "description": "Comments." },
+          "category": {
+            "type": "string",
+            "description": "Contact category."
+          },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "company": {
             "type": "string",
             "description": "Company where the contact is employed."
@@ -13402,17 +16923,36 @@
           "customFields": {
             "type": "array",
             "description": "Custom fields.",
-            "items": { "$ref": "#/components/schemas/CustomField" }
+            "items": {
+              "$ref": "#/components/schemas/CustomField"
+            }
           },
-          "email": { "type": "string", "description": "E-mail address." },
-          "fax": { "type": "string", "description": "Fax." },
-          "firstName": { "type": "string", "description": "First name." },
+          "email": {
+            "type": "string",
+            "description": "E-mail address."
+          },
+          "fax": {
+            "type": "string",
+            "description": "Fax."
+          },
+          "firstName": {
+            "type": "string",
+            "description": "First name."
+          },
           "gender": {
             "type": "string",
             "description": "Gender.",
-            "enum": ["UNKNOWN", "MALE", "FEMALE", "DECLINE_TO_STATE"]
+            "enum": [
+              "UNKNOWN",
+              "MALE",
+              "FEMALE",
+              "DECLINE_TO_STATE"
+            ]
           },
-          "homePhone": { "type": "string", "description": "Home phone." },
+          "homePhone": {
+            "type": "string",
+            "description": "Home phone."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -13431,24 +16971,54 @@
             "format": "date-time",
             "description": "Date and time the record was last modified. (Timezone: UTC)"
           },
-          "lastName": { "type": "string", "description": "Last name." },
-          "middleName": { "type": "string", "description": "Middle name." },
-          "mobilePhone": { "type": "string", "description": "Mobile phone." },
-          "nameOnCheck": { "type": "string", "description": "Name on check." },
+          "lastName": {
+            "type": "string",
+            "description": "Last name."
+          },
+          "middleName": {
+            "type": "string",
+            "description": "Middle name."
+          },
+          "mobilePhone": {
+            "type": "string",
+            "description": "Mobile phone."
+          },
+          "nameOnCheck": {
+            "type": "string",
+            "description": "Name on check."
+          },
           "namedOnLease": {
             "type": "boolean",
             "example": false,
             "description": "Indicates if contact is named on lease."
           },
-          "otherPhone": { "type": "string", "description": "Other phone." },
-          "salutation": { "type": "string", "description": "Salutation." },
-          "suffix": { "type": "string", "description": "Suffix." },
+          "otherPhone": {
+            "type": "string",
+            "description": "Other phone."
+          },
+          "salutation": {
+            "type": "string",
+            "description": "Salutation."
+          },
+          "suffix": {
+            "type": "string",
+            "description": "Suffix."
+          },
           "type": {
             "type": "string",
             "description": "Contact type.",
-            "enum": ["TENANT", "PROSPECT", "OWNER", "VENDOR", "OTHER"]
+            "enum": [
+              "TENANT",
+              "PROSPECT",
+              "OWNER",
+              "VENDOR",
+              "OTHER"
+            ]
           },
-          "workPhone": { "type": "string", "description": "Work phone." }
+          "workPhone": {
+            "type": "string",
+            "description": "Work phone."
+          }
         },
         "description": "Contact Response"
       },
@@ -13464,11 +17034,15 @@
             "example": false,
             "description": "Indicates if the property is active or inactive."
           },
-          "address": { "$ref": "#/components/schemas/Address" },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
           "amenities": {
             "type": "array",
             "description": "Property amenities list.",
-            "items": { "$ref": "#/components/schemas/Amenity" }
+            "items": {
+              "$ref": "#/components/schemas/Amenity"
+            }
           },
           "applicationFeeRule": {
             "type": "string",
@@ -13477,12 +17051,19 @@
           "areaUnits": {
             "type": "string",
             "description": "Property total area units.",
-            "enum": ["Sq Ft", "Sq M"]
+            "enum": [
+              "Sq Ft",
+              "Sq M"
+            ],
+            "default": "Sq Ft"
           },
           "category": {
             "type": "string",
             "description": "Property category.",
-            "enum": ["RESIDENTIAL", "COMMERCIAL"]
+            "enum": [
+              "RESIDENTIAL",
+              "COMMERCIAL"
+            ]
           },
           "countUnit": {
             "type": "integer",
@@ -13505,7 +17086,9 @@
           "customFields": {
             "type": "array",
             "description": "Custom fields.",
-            "items": { "$ref": "#/components/schemas/CustomField" }
+            "items": {
+              "$ref": "#/components/schemas/CustomField"
+            }
           },
           "floorNumber": {
             "type": "integer",
@@ -13571,15 +17154,26 @@
           "maintenanceSpendingLimitTime": {
             "type": "string",
             "description": "Property maintenance spending limit.",
-            "enum": ["NO_LIMIT", "MONTHLY_LIMIT", "YEARLY_LIMIT"]
+            "enum": [
+              "NO_LIMIT",
+              "MONTHLY_LIMIT",
+              "YEARLY_LIMIT"
+            ]
           },
-          "management": { "$ref": "#/components/schemas/ManagementSettings" },
-          "marketing": { "$ref": "#/components/schemas/Marketing" },
+          "management": {
+            "$ref": "#/components/schemas/ManagementSettings"
+          },
+          "marketing": {
+            "$ref": "#/components/schemas/Marketing"
+          },
           "multiUnit": {
             "type": "string",
             "description": "Indicates if the building is multi family or single family."
           },
-          "name": { "type": "string", "description": "Name of the property." },
+          "name": {
+            "type": "string",
+            "description": "Name of the property."
+          },
           "neighborhood": {
             "type": "string",
             "description": "Property neighborhood."
@@ -13607,7 +17201,9 @@
           "propertyManagerList": {
             "type": "array",
             "description": "Property manager details.",
-            "items": { "$ref": "#/components/schemas/PropertyManager" }
+            "items": {
+              "$ref": "#/components/schemas/PropertyManager"
+            }
           },
           "propertyType": {
             "type": "string",
@@ -13682,7 +17278,10 @@
             "format": "double",
             "description": "Property total area."
           },
-          "type": { "type": "string", "description": "Property type." },
+          "type": {
+            "type": "string",
+            "description": "Property type."
+          },
           "website": {
             "type": "string",
             "description": "Property website URL."
@@ -13697,7 +17296,12 @@
       },
       "RESTAPIBulkSuccessResponse": {
         "type": "object",
-        "properties": { "id": { "type": "integer", "format": "int64" } }
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
       },
       "SaveBillPayment": {
         "type": "object",
@@ -13705,13 +17309,18 @@
           "bills": {
             "type": "array",
             "description": "Bills to pay.",
-            "items": { "$ref": "#/components/schemas/BillPay" }
+            "items": {
+              "$ref": "#/components/schemas/BillPay"
+            }
           },
           "checkNumber": {
             "type": "string",
             "description": "Payment check number."
           },
-          "memo": { "type": "string", "description": "Memo." },
+          "memo": {
+            "type": "string",
+            "description": "Memo."
+          },
           "paymentAccountID": {
             "type": "integer",
             "format": "int64",
@@ -13725,7 +17334,12 @@
           "paymentMethod": {
             "type": "string",
             "description": "Payment method.",
-            "enum": ["Check", "Cash", "Bank Bill Pay", "Online Bank Transfer"]
+            "enum": [
+              "Check",
+              "Cash",
+              "Bank Bill Pay",
+              "Online Bank Transfer"
+            ]
           },
           "vendorID": {
             "type": "integer",
@@ -13736,7 +17350,12 @@
       },
       "Check": {
         "type": "object",
-        "required": ["amount", "date", "destinationAccountID", "payeePayer"],
+        "required": [
+          "amount",
+          "date",
+          "destinationAccountID",
+          "payeePayer"
+        ],
         "properties": {
           "amount": {
             "type": "number",
@@ -13746,9 +17365,14 @@
           "checkSplits": {
             "type": "array",
             "description": "List of check splits.",
-            "items": { "$ref": "#/components/schemas/CheckSplit" }
+            "items": {
+              "$ref": "#/components/schemas/CheckSplit"
+            }
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -13803,7 +17427,8 @@
               "ECHECK",
               "NACHA",
               "RENTMONEY",
-              "PUBLIC_ASSISTANCE"
+              "PUBLIC_ASSISTANCE",
+              "PAYMENT_TYPE_NA"
             ]
           },
           "portfolioID": {
@@ -13811,7 +17436,10 @@
             "format": "int64",
             "description": "Id of the portfolio associated with this transaction."
           },
-          "refNo": { "type": "string", "description": "Reference number." },
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          },
           "toBePrinted": {
             "type": "boolean",
             "example": false,
@@ -13827,7 +17455,9 @@
       },
       "SaveAddress": {
         "type": "object",
-        "required": ["country"],
+        "required": [
+          "country"
+        ],
         "properties": {
           "address": {
             "type": "string",
@@ -13871,7 +17501,11 @@
           "cashAccrual": {
             "type": "string",
             "description": "Cash or accrual accounting basis.",
-            "enum": ["COMPANY_DEFAULT", "CASH", "ACCRUAL"]
+            "enum": [
+              "COMPANY_DEFAULT",
+              "CASH",
+              "ACCRUAL"
+            ]
           },
           "closingDate": {
             "type": "string",
@@ -13890,7 +17524,9 @@
           "customFields": {
             "type": "array",
             "description": "Custom fields.",
-            "items": { "$ref": "#/components/schemas/CustomField" }
+            "items": {
+              "$ref": "#/components/schemas/CustomField"
+            }
           },
           "defaultBankAccountID": {
             "type": "integer",
@@ -13937,13 +17573,20 @@
           "maintenanceSpendingLimitTime": {
             "type": "string",
             "description": "Monthly or yearly maintenance spending limit time set for the portfolio for maintenance bills created by work orders.",
-            "enum": ["NO_LIMIT", "DOLLAR_PER_MONTH", "DOLLAR_PER_YEAR"]
+            "enum": [
+              "NO_LIMIT",
+              "DOLLAR_PER_MONTH",
+              "DOLLAR_PER_YEAR"
+            ]
           },
           "modifiedBy": {
             "type": "string",
             "description": "Id of the user who last modified the portfolio information."
           },
-          "name": { "type": "string", "description": "Portfolio name." },
+          "name": {
+            "type": "string",
+            "description": "Portfolio name."
+          },
           "ownerStatementReportID": {
             "type": "integer",
             "format": "int64",
@@ -13952,9 +17595,14 @@
           "owners": {
             "type": "array",
             "description": "List of portfolio owners.",
-            "items": { "$ref": "#/components/schemas/Owner" }
+            "items": {
+              "$ref": "#/components/schemas/Owner"
+            }
           },
-          "stickyNote": { "type": "string", "description": "Sticky notes." },
+          "stickyNote": {
+            "type": "string",
+            "description": "Sticky notes."
+          },
           "targetOperatingReserve": {
             "type": "number",
             "format": "double",
@@ -13965,26 +17613,52 @@
       },
       "SaveProspectContact": {
         "type": "object",
-        "required": ["firstName", "lastName"],
+        "required": [
+          "firstName",
+          "lastName"
+        ],
         "properties": {
-          "address": { "$ref": "#/components/schemas/SaveAddress" },
-          "email": { "type": "string", "description": " EMail." },
-          "firstName": { "type": "string", "description": "First Name." },
-          "homePhone": { "type": "string", "description": " Home Phone." },
+          "address": {
+            "$ref": "#/components/schemas/SaveAddress"
+          },
+          "email": {
+            "type": "string",
+            "description": " EMail."
+          },
+          "firstName": {
+            "type": "string",
+            "description": "First Name."
+          },
+          "homePhone": {
+            "type": "string",
+            "description": " Home Phone."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
             "description": "Unique identifier."
           },
-          "lastName": { "type": "string", "description": " Last Name." },
-          "mobilePhone": { "type": "string", "description": " Mobile Phone." },
-          "otherPhone": { "type": "string", "description": " Other Phone." },
+          "lastName": {
+            "type": "string",
+            "description": " Last Name."
+          },
+          "mobilePhone": {
+            "type": "string",
+            "description": " Mobile Phone."
+          },
+          "otherPhone": {
+            "type": "string",
+            "description": " Other Phone."
+          },
           "percentageship": {
             "type": "number",
             "format": "double",
             "description": "ship percentage."
           },
-          "workPhone": { "type": "string", "description": " Work Phone." }
+          "workPhone": {
+            "type": "string",
+            "description": " Work Phone."
+          }
         },
         "description": "Save Prospect Contact"
       },
@@ -13999,18 +17673,37 @@
             "type": "string",
             "description": "Address continuation."
           },
-          "city": { "type": "string", "description": "City." },
-          "country": { "type": "string", "description": "Country." },
-          "postalCode": { "type": "string", "description": "Postal code." },
-          "stateRegion": { "type": "string", "description": "State/region." }
+          "city": {
+            "type": "string",
+            "description": "City."
+          },
+          "country": {
+            "type": "string",
+            "description": "Country."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Postal code."
+          },
+          "stateRegion": {
+            "type": "string",
+            "description": "State/region."
+          }
         },
         "description": "Address"
       },
       "SaveLeaseJournalEntry": {
         "type": "object",
-        "required": ["comments", "date", "leaseID"],
+        "required": [
+          "comments",
+          "date",
+          "leaseID"
+        ],
         "properties": {
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "date": {
             "type": "string",
             "format": "date",
@@ -14019,7 +17712,9 @@
           "journalEntrySplit": {
             "type": "array",
             "description": "Journal Entry Splits.",
-            "items": { "$ref": "#/components/schemas/SaveJournalEntrySplit" }
+            "items": {
+              "$ref": "#/components/schemas/SaveJournalEntrySplit"
+            }
           },
           "leaseID": {
             "type": "integer",
@@ -14039,7 +17734,9 @@
           "comments": {
             "type": "array",
             "description": "List of comments in the conversation.",
-            "items": { "$ref": "#/components/schemas/Comment" }
+            "items": {
+              "$ref": "#/components/schemas/Comment"
+            }
           },
           "createdBy": {
             "type": "string",
@@ -14080,7 +17777,11 @@
           "type": {
             "type": "string",
             "description": "Conversation type.",
-            "enum": ["MANAGEMENT_TEAM", "OWNER", "TENANT"]
+            "enum": [
+              "MANAGEMENT_TEAM",
+              "OWNER",
+              "TENANT"
+            ]
           }
         },
         "description": "Conversation"
@@ -14139,14 +17840,23 @@
       "PropertyManager": {
         "type": "object",
         "properties": {
-          "email": { "type": "string", "description": "Email address." },
+          "email": {
+            "type": "string",
+            "description": "Email address."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
             "description": "Unique identifier."
           },
-          "name": { "type": "string", "description": "Name." },
-          "roleAsString": { "type": "string", "description": "Role name." },
+          "name": {
+            "type": "string",
+            "description": "Name."
+          },
+          "roleAsString": {
+            "type": "string",
+            "description": "Role name."
+          },
           "userID": {
             "type": "integer",
             "format": "int64",
@@ -14170,7 +17880,9 @@
           "contacts": {
             "type": "array",
             "description": "Prospect contacts.",
-            "items": { "$ref": "#/components/schemas/SaveProspectContact" }
+            "items": {
+              "$ref": "#/components/schemas/SaveProspectContact"
+            }
           },
           "currentHomeType": {
             "type": "string",
@@ -14210,7 +17922,10 @@
             "format": "int32",
             "description": "Prospect Number Of Pets."
           },
-          "petType": { "type": "string", "description": "Prospect Pet Type." },
+          "petType": {
+            "type": "string",
+            "description": "Prospect Pet Type."
+          },
           "petWeights": {
             "type": "string",
             "description": "Prospect Pet Weights."
@@ -14227,7 +17942,10 @@
             "type": "string",
             "description": "Property Address Continued."
           },
-          "propertyCity": { "type": "string", "description": "Property City." },
+          "propertyCity": {
+            "type": "string",
+            "description": "Property City."
+          },
           "propertyCountry": {
             "type": "string",
             "description": "Property Country."
@@ -14246,7 +17964,10 @@
             "type": "string",
             "description": "Property State."
           },
-          "propertyZip": { "type": "string", "description": "Property Zip." },
+          "propertyZip": {
+            "type": "string",
+            "description": "Property Zip."
+          },
           "reasonForMoving": {
             "type": "string",
             "description": "Prospect Reason For Moving."
@@ -14261,13 +17982,22 @@
             "format": "double",
             "description": "Prospect Rent Minimum."
           },
-          "source": { "type": "string", "description": "Prospect Source." },
-          "status": { "type": "string", "description": "Prospect Status." },
+          "source": {
+            "type": "string",
+            "description": "Prospect Source."
+          },
+          "status": {
+            "type": "string",
+            "description": "Prospect Status."
+          },
           "timeAtCurrentResidence": {
             "type": "string",
             "description": "Prospect Time At Current Residence."
           },
-          "type": { "type": "string", "description": "Prospect Type." },
+          "type": {
+            "type": "string",
+            "description": "Prospect Type."
+          },
           "typeOfInquiry": {
             "type": "string",
             "description": "Prospect Type Of Inquiry."
@@ -14278,25 +18008,51 @@
       "Owner": {
         "type": "object",
         "properties": {
-          "address": { "$ref": "#/components/schemas/Address" },
-          "email": { "type": "string", "description": "Email address." },
-          "firstName": { "type": "string", "description": "First name." },
-          "homePhone": { "type": "string", "description": "Home phone." },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "email": {
+            "type": "string",
+            "description": "Email address."
+          },
+          "firstName": {
+            "type": "string",
+            "description": "First name."
+          },
+          "homePhone": {
+            "type": "string",
+            "description": "Home phone."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
             "description": "Unique identifier."
           },
-          "lastName": { "type": "string", "description": "Last name." },
-          "mobilePhone": { "type": "string", "description": "Mobile phone." },
-          "name": { "type": "string", "description": "Full name." },
-          "otherPhone": { "type": "string", "description": "Other phone." },
+          "lastName": {
+            "type": "string",
+            "description": "Last name."
+          },
+          "mobilePhone": {
+            "type": "string",
+            "description": "Mobile phone."
+          },
+          "name": {
+            "type": "string",
+            "description": "Full name."
+          },
+          "otherPhone": {
+            "type": "string",
+            "description": "Other phone."
+          },
           "percentageOwnership": {
             "type": "number",
             "format": "double",
             "description": "Percentage ownership."
           },
-          "workPhone": { "type": "string", "description": "Work phone." }
+          "workPhone": {
+            "type": "string",
+            "description": "Work phone."
+          }
         },
         "description": "Owner Contact"
       },
@@ -14315,7 +18071,10 @@
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "date": {
             "type": "string",
             "format": "date",
@@ -14336,7 +18095,10 @@
             "format": "int64",
             "description": "Id of the lease associated with the refund."
           },
-          "refNo": { "type": "string", "description": "Reference number." },
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          },
           "toBePrinted": {
             "type": "boolean",
             "example": false,
@@ -14363,7 +18125,10 @@
             "example": false,
             "description": "Read Only"
           },
-          "status": { "type": "string", "description": "Status" },
+          "status": {
+            "type": "string",
+            "description": "Status"
+          },
           "visibleOnPortal": {
             "type": "boolean",
             "example": false,
@@ -14374,7 +18139,11 @@
       },
       "PaymentCharge": {
         "type": "object",
-        "required": ["amount", "date", "settledDate"],
+        "required": [
+          "amount",
+          "date",
+          "settledDate"
+        ],
         "properties": {
           "accountID": {
             "type": "integer",
@@ -14386,13 +18155,19 @@
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "date": {
             "type": "string",
             "format": "date",
             "description": "Payment applied date."
           },
-          "payeePayer": { "type": "string", "description": "Payer name." },
+          "payeePayer": {
+            "type": "string",
+            "description": "Payer name."
+          },
           "paymentType": {
             "type": "string",
             "description": "Payment type. Electronic payments are only for book keeping.",
@@ -14410,7 +18185,8 @@
               "ECHECK",
               "NACHA",
               "RENTMONEY",
-              "PUBLIC_ASSISTANCE"
+              "PUBLIC_ASSISTANCE",
+              "PAYMENT_TYPE_NA"
             ]
           },
           "receiptNumber": {
@@ -14446,16 +18222,24 @@
             "example": false,
             "description": "Indicates if the property is active or inactive."
           },
-          "address": { "$ref": "#/components/schemas/Address" },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
           "amenities": {
             "type": "array",
             "description": "Property amenities list.",
-            "items": { "$ref": "#/components/schemas/Amenity" }
+            "items": {
+              "$ref": "#/components/schemas/Amenity"
+            }
           },
           "areaUnits": {
             "type": "string",
             "description": "Property total area units.",
-            "enum": ["Sq Ft", "Sq M"]
+            "enum": [
+              "Sq Ft",
+              "Sq M"
+            ],
+            "default": "Sq Ft"
           },
           "buildingID": {
             "type": "integer",
@@ -14465,7 +18249,10 @@
           "category": {
             "type": "string",
             "description": "Property category.",
-            "enum": ["RESIDENTIAL", "COMMERCIAL"]
+            "enum": [
+              "RESIDENTIAL",
+              "COMMERCIAL"
+            ]
           },
           "county": {
             "type": "string",
@@ -14483,7 +18270,9 @@
           "customFields": {
             "type": "array",
             "description": "Custom fields.",
-            "items": { "$ref": "#/components/schemas/CustomField" }
+            "items": {
+              "$ref": "#/components/schemas/CustomField"
+            }
           },
           "floorNumber": {
             "type": "integer",
@@ -14521,11 +18310,22 @@
           "maintenanceSpendingLimitTime": {
             "type": "string",
             "description": "Property maintenance spending limit.",
-            "enum": ["NO_LIMIT", "MONTHLY_LIMIT", "YEARLY_LIMIT"]
+            "enum": [
+              "NO_LIMIT",
+              "MONTHLY_LIMIT",
+              "YEARLY_LIMIT"
+            ]
           },
-          "management": { "$ref": "#/components/schemas/ManagementSettings" },
-          "marketing": { "$ref": "#/components/schemas/Marketing" },
-          "name": { "type": "string", "description": "Name of the property." },
+          "management": {
+            "$ref": "#/components/schemas/ManagementSettings"
+          },
+          "marketing": {
+            "$ref": "#/components/schemas/Marketing"
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the property."
+          },
           "neighborhood": {
             "type": "string",
             "description": "Property neighborhood."
@@ -14553,7 +18353,9 @@
           "propertyManagerList": {
             "type": "array",
             "description": "Property manager details.",
-            "items": { "$ref": "#/components/schemas/PropertyManager" }
+            "items": {
+              "$ref": "#/components/schemas/PropertyManager"
+            }
           },
           "ready": {
             "type": "boolean",
@@ -14606,7 +18408,10 @@
             "format": "double",
             "description": "Property total area."
           },
-          "type": { "type": "string", "description": "Property type." },
+          "type": {
+            "type": "string",
+            "description": "Property type."
+          },
           "website": {
             "type": "string",
             "description": "Property website URL."
@@ -14621,21 +18426,41 @@
       },
       "SaveVendor": {
         "type": "object",
-        "required": ["companyName", "name", "nameOnCheck", "vendorType"],
+        "required": [
+          "companyName",
+          "name",
+          "nameOnCheck",
+          "vendorType"
+        ],
         "properties": {
           "accountNumber": {
             "type": "string",
             "description": "Account Number"
           },
-          "address": { "type": "string", "description": "Address" },
-          "address2": { "type": "string", "description": "Address2" },
-          "alertEmail": { "type": "string", "description": "Alert Email" },
-          "city": { "type": "string", "description": "City" },
+          "address": {
+            "type": "string",
+            "description": "Address"
+          },
+          "address2": {
+            "type": "string",
+            "description": "Address2"
+          },
+          "alertEmail": {
+            "type": "string",
+            "description": "Alert Email"
+          },
+          "city": {
+            "type": "string",
+            "description": "City"
+          },
           "companyName": {
             "type": "string",
             "description": "Vendor Company Name"
           },
-          "country": { "type": "string", "description": "Country" },
+          "country": {
+            "type": "string",
+            "description": "Country"
+          },
           "creditLimit": {
             "type": "number",
             "format": "double",
@@ -14645,7 +18470,16 @@
             "type": "integer",
             "format": "int32",
             "description": "Payment Terms days to pay.",
-            "enum": [0, 5, 10, 15, 30, 45, 60, 90]
+            "enum": [
+              0,
+              5,
+              10,
+              15,
+              30,
+              45,
+              60,
+              90
+            ]
           },
           "defaultBillSplitAccountId": {
             "type": "integer",
@@ -14657,14 +18491,23 @@
             "format": "double",
             "description": "Default markup discount"
           },
-          "description": { "type": "string", "description": "Description" },
+          "description": {
+            "type": "string",
+            "description": "Description"
+          },
           "eligible1099": {
             "type": "boolean",
             "example": false,
             "description": "Eligible For 1099"
           },
-          "email": { "type": "string", "description": "EMail" },
-          "fax": { "type": "string", "description": "Fax" },
+          "email": {
+            "type": "string",
+            "description": "EMail"
+          },
+          "fax": {
+            "type": "string",
+            "description": "Fax"
+          },
           "includeCompanyNameOn1099": {
             "type": "boolean",
             "example": false,
@@ -14675,21 +18518,39 @@
             "format": "int64",
             "description": "Markup account id"
           },
-          "name": { "type": "string", "description": "Vendor Name" },
+          "name": {
+            "type": "string",
+            "description": "Vendor Name"
+          },
           "nameOnCheck": {
             "type": "string",
             "description": "Vendor Name On Check"
           },
-          "phone": { "type": "string", "description": "Phone" },
-          "searchTag": { "type": "string", "description": "Search Tag" },
-          "state": { "type": "string", "description": "State" },
+          "phone": {
+            "type": "string",
+            "description": "Phone"
+          },
+          "searchTag": {
+            "type": "string",
+            "description": "Search Tag"
+          },
+          "state": {
+            "type": "string",
+            "description": "State"
+          },
           "syncToVMM": {
             "type": "boolean",
             "example": false,
             "description": "Sync to maintenance"
           },
-          "taxID": { "type": "string", "description": "Tax ID" },
-          "taxPayerName": { "type": "string", "description": "Tax Payer Name" },
+          "taxID": {
+            "type": "string",
+            "description": "Tax ID"
+          },
+          "taxPayerName": {
+            "type": "string",
+            "description": "Tax Payer Name"
+          },
           "terms": {
             "type": "string",
             "description": "Payment Terms Description, default value('NET 30')"
@@ -14703,14 +18564,24 @@
             "type": "string",
             "description": "Vendor type. This is a user configurable list with the following initial default values <Banking - General>,\n <Banking - Mortgage>, <Banking - Investment>, <Contractors - Carpentry>, <Contractors - Dry Wall>, <Contractors - Electrical>, <Contractors - Fencing>, <Contractors - Flooring>, <Contractors - General>, <Contractors - HVAC>, <Contractors - Landscaping>, <Contractors - Masonry>, <Contractors - Miscellaneous>, <Contractors - Painting>, <Contractors - Paving>, <Contractors - Plumbing>, <Contractors - Roofing>, <Contractors - Sheet Metal>, <Contractors - Windows>, <Owners>, <Management Company>, <Suppliers - Carpets>, <Suppliers - Electrical>, <Suppliers - General>, <Suppliers - Lighting>, <Suppliers - Lumber>, <Suppliers - Plumbing>, <Suppliers - Security>, <Suppliers - Stone>, <Suppliers - Tiling>, <Suppliers - Windows>, <Utilities - Communications>, <Utilities - Gas & Electric>, <Utilities - Waste Management>, <Utilities - Water>"
           },
-          "website": { "type": "string", "description": "Website" },
-          "zip": { "type": "string", "description": "Zip" }
+          "website": {
+            "type": "string",
+            "description": "Website"
+          },
+          "zip": {
+            "type": "string",
+            "description": "Zip"
+          }
         },
         "description": "Vendor for Request"
       },
       "SaveJournalEntrySplit": {
         "type": "object",
-        "required": ["creditAmount", "debitAmount", "glAccountID"],
+        "required": [
+          "creditAmount",
+          "debitAmount",
+          "glAccountID"
+        ],
         "properties": {
           "creditAmount": {
             "type": "number",
@@ -14758,18 +18629,30 @@
             "type": "string",
             "description": "Bank address line 2."
           },
-          "bankCity": { "type": "string", "description": "City." },
-          "bankInstitution": { "type": "string", "description": "Bank name." },
+          "bankCity": {
+            "type": "string",
+            "description": "City."
+          },
+          "bankInstitution": {
+            "type": "string",
+            "description": "Bank name."
+          },
           "bankRoutingNumberDecrypted": {
             "type": "string",
             "description": "Bank routing number."
           },
-          "bankState": { "type": "string", "description": "State." },
+          "bankState": {
+            "type": "string",
+            "description": "State."
+          },
           "bankTransitFraction": {
             "type": "string",
             "description": "Bank transit fraction."
           },
-          "bankZip": { "type": "string", "description": "Zip." },
+          "bankZip": {
+            "type": "string",
+            "description": "Zip."
+          },
           "depositTicketType": {
             "type": "integer",
             "format": "int32",
@@ -14819,7 +18702,9 @@
           "managementFees": {
             "type": "array",
             "description": "List of property management fee rules.",
-            "items": { "$ref": "#/components/schemas/ManagementFee" }
+            "items": {
+              "$ref": "#/components/schemas/ManagementFee"
+            }
           },
           "managementFlatFee": {
             "type": "number",
@@ -14831,14 +18716,20 @@
       },
       "SaveAdjustment": {
         "type": "object",
-        "required": ["amount", "leaseID"],
+        "required": [
+          "amount",
+          "leaseID"
+        ],
         "properties": {
           "amount": {
             "type": "number",
             "format": "double",
             "description": "Amount, should be negative."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "date": {
             "type": "string",
             "format": "date",
@@ -14849,7 +18740,10 @@
             "format": "int64",
             "description": "Id of the lease associated with the Adjustment."
           },
-          "refNo": { "type": "string", "description": "Reference number." }
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          }
         },
         "description": "Adjustment for Request"
       },
@@ -14864,7 +18758,9 @@
           "bills": {
             "type": "array",
             "description": "List of bills that were paid.",
-            "items": { "$ref": "#/components/schemas/BillPaid" }
+            "items": {
+              "$ref": "#/components/schemas/BillPaid"
+            }
           },
           "checkNumber": {
             "type": "string",
@@ -14893,8 +18789,14 @@
             "format": "date-time",
             "description": "Date and time the record was last modified. (Timezone: UTC)"
           },
-          "memo": { "type": "string", "description": "Memo." },
-          "nameOnCheck": { "type": "string", "description": "Name on check." },
+          "memo": {
+            "type": "string",
+            "description": "Memo."
+          },
+          "nameOnCheck": {
+            "type": "string",
+            "description": "Name on check."
+          },
           "paymentAccountID": {
             "type": "integer",
             "format": "int64",
@@ -14924,9 +18826,14 @@
       },
       "SaveContact": {
         "type": "object",
-        "required": ["firstName", "lastName"],
+        "required": [
+          "firstName",
+          "lastName"
+        ],
         "properties": {
-          "address": { "$ref": "#/components/schemas/SaveAddress" },
+          "address": {
+            "$ref": "#/components/schemas/SaveAddress"
+          },
           "allowESignature": {
             "type": "boolean",
             "example": false,
@@ -14945,15 +18852,24 @@
             "type": "string",
             "description": "Indicate contact category. Send empty \"\" value if contact is Uncategorized"
           },
-          "comments": { "type": "string", "description": "Description." },
+          "comments": {
+            "type": "string",
+            "description": "Description."
+          },
           "company": {
             "type": "string",
             "description": "Company where the contact is employed.",
             "minLength": 1,
             "maxLength": 75
           },
-          "email": { "type": "string", "description": "E-mail Address." },
-          "fax": { "type": "string", "description": "Fax." },
+          "email": {
+            "type": "string",
+            "description": "E-mail Address."
+          },
+          "fax": {
+            "type": "string",
+            "description": "Fax."
+          },
           "firstName": {
             "type": "string",
             "description": "First Name.",
@@ -14963,7 +18879,12 @@
           "gender": {
             "type": "string",
             "description": "Gender.",
-            "enum": ["UNKNOWN", "MALE", "FEMALE", "DECLINE_TO_STATE"]
+            "enum": [
+              "UNKNOWN",
+              "MALE",
+              "FEMALE",
+              "DECLINE_TO_STATE"
+            ]
           },
           "homePhone": {
             "type": "string",
@@ -15012,9 +18933,18 @@
             "minLength": 1,
             "maxLength": 22
           },
-          "salutation": { "type": "string", "description": "Salutation." },
-          "searchTag": { "type": "string", "description": "SearchTag." },
-          "suffix": { "type": "string", "description": "Suffix." },
+          "salutation": {
+            "type": "string",
+            "description": "Salutation."
+          },
+          "searchTag": {
+            "type": "string",
+            "description": "SearchTag."
+          },
+          "suffix": {
+            "type": "string",
+            "description": "Suffix."
+          },
           "workPhone": {
             "type": "string",
             "description": "Work Phone.",
@@ -15026,14 +18956,20 @@
       },
       "Discount": {
         "type": "object",
-        "required": ["amount", "date"],
+        "required": [
+          "amount",
+          "date"
+        ],
         "properties": {
           "amount": {
             "type": "number",
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -15077,21 +19013,33 @@
             "format": "int64",
             "description": "Id of the portfolio associated with this transaction."
           },
-          "refNo": { "type": "string", "description": "Reference number." }
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          }
         },
         "description": "Discount"
       },
       "Amenity": {
         "type": "object",
         "properties": {
-          "code": { "type": "string", "description": "Amenity code." },
+          "code": {
+            "type": "string",
+            "description": "Amenity code."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
             "description": "Unique identifier."
           },
-          "name": { "type": "string", "description": "Amenity name." },
-          "type": { "type": "string", "description": "Amenity type." }
+          "name": {
+            "type": "string",
+            "description": "Amenity name."
+          },
+          "type": {
+            "type": "string",
+            "description": "Amenity type."
+          }
         },
         "description": "Amenity"
       },
@@ -15165,7 +19113,10 @@
       "ContactCategory": {
         "type": "object",
         "properties": {
-          "categoryName": { "type": "string", "description": "Category name." },
+          "categoryName": {
+            "type": "string",
+            "description": "Category name."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -15176,7 +19127,9 @@
       },
       "CheckSplit": {
         "type": "object",
-        "required": ["portfolioID"],
+        "required": [
+          "portfolioID"
+        ],
         "properties": {
           "amount": {
             "type": "number",
@@ -15188,7 +19141,10 @@
             "format": "int64",
             "description": "Id of the building associated with this check split."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "glAccountID": {
             "type": "integer",
             "format": "int64",
@@ -15251,7 +19207,9 @@
           "inspectionAreas": {
             "type": "array",
             "description": "List of inspection areas.",
-            "items": { "$ref": "#/components/schemas/InspectionArea" }
+            "items": {
+              "$ref": "#/components/schemas/InspectionArea"
+            }
           },
           "inspectorID": {
             "type": "integer",
@@ -15291,25 +19249,37 @@
             "format": "date-time",
             "description": "Date and time the inspection is/was scheduled to occur (customer time zone)."
           },
-          "status": { "type": "string", "description": "Inspection status." },
+          "status": {
+            "type": "string",
+            "description": "Inspection status."
+          },
           "templateName": {
             "type": "string",
             "description": "Inspection template name."
           },
-          "type": { "type": "string", "description": "Inspection type." }
+          "type": {
+            "type": "string",
+            "description": "Inspection type."
+          }
         },
         "description": "Inspection"
       },
       "OwnerDraw": {
         "type": "object",
-        "required": ["amount", "date"],
+        "required": [
+          "amount",
+          "date"
+        ],
         "properties": {
           "amount": {
             "type": "number",
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "contactID": {
             "type": "integer",
             "format": "int64",
@@ -15370,7 +19340,8 @@
               "ECHECK",
               "NACHA",
               "RENTMONEY",
-              "PUBLIC_ASSISTANCE"
+              "PUBLIC_ASSISTANCE",
+              "PAYMENT_TYPE_NA"
             ]
           },
           "portfolioID": {
@@ -15378,20 +19349,29 @@
             "format": "int64",
             "description": "Id of the portfolio associated with this owner draw."
           },
-          "refNo": { "type": "string", "description": "Reference number." }
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          }
         },
         "description": "Owner Draw"
       },
       "CreditMemo": {
         "type": "object",
-        "required": ["amount", "date"],
+        "required": [
+          "amount",
+          "date"
+        ],
         "properties": {
           "amount": {
             "type": "number",
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments" },
+          "comments": {
+            "type": "string",
+            "description": "Comments"
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -15440,13 +19420,19 @@
             "format": "int64",
             "description": "Id of the portfolio associated with this credit memo."
           },
-          "refNo": { "type": "string", "description": "Reference number." }
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          }
         },
         "description": "Transaction"
       },
       "SaveCredit": {
         "type": "object",
-        "required": ["billDate", "vendorID"],
+        "required": [
+          "billDate",
+          "vendorID"
+        ],
         "properties": {
           "billDate": {
             "type": "string",
@@ -15456,10 +19442,18 @@
           "billSplits": {
             "type": "array",
             "description": "Splits list.",
-            "items": { "$ref": "#/components/schemas/SaveBillSplit" }
+            "items": {
+              "$ref": "#/components/schemas/SaveBillSplit"
+            }
           },
-          "comments": { "type": "string", "description": "Description." },
-          "refNo": { "type": "string", "description": "Reference number." },
+          "comments": {
+            "type": "string",
+            "description": "Description."
+          },
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          },
           "vendorID": {
             "type": "integer",
             "format": "int64",
@@ -15479,7 +19473,9 @@
           "items": {
             "type": "array",
             "description": "List of items in the inspection.",
-            "items": { "$ref": "#/components/schemas/InspectionItem" }
+            "items": {
+              "$ref": "#/components/schemas/InspectionItem"
+            }
           },
           "name": {
             "type": "string",
@@ -15491,7 +19487,10 @@
       "JournalEntry": {
         "type": "object",
         "properties": {
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -15550,16 +19549,34 @@
             "example": false,
             "description": "Indicates if the vendor is active."
           },
-          "address": { "type": "string", "description": "Address." },
-          "address2": { "type": "string", "description": "Address line 2." },
-          "alertEmail": { "type": "string", "description": "Alert Email" },
-          "city": { "type": "string", "description": "City." },
-          "comments": { "type": "string", "description": "Comments." },
+          "address": {
+            "type": "string",
+            "description": "Address."
+          },
+          "address2": {
+            "type": "string",
+            "description": "Address line 2."
+          },
+          "alertEmail": {
+            "type": "string",
+            "description": "Alert Email"
+          },
+          "city": {
+            "type": "string",
+            "description": "City."
+          },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "companyName": {
             "type": "string",
             "description": "Name of the vendor's company."
           },
-          "country": { "type": "string", "description": "Country." },
+          "country": {
+            "type": "string",
+            "description": "Country."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -15577,7 +19594,9 @@
           "customFields": {
             "type": "array",
             "description": "Custom fields.",
-            "items": { "$ref": "#/components/schemas/CustomField" }
+            "items": {
+              "$ref": "#/components/schemas/CustomField"
+            }
           },
           "defaultBillSplitAccountId": {
             "type": "integer",
@@ -15589,14 +19608,23 @@
             "format": "double",
             "description": "Default markup discount"
           },
-          "description": { "type": "string", "description": "Description." },
+          "description": {
+            "type": "string",
+            "description": "Description."
+          },
           "eligible1099": {
             "type": "boolean",
             "example": false,
             "description": "Indicates if the vendor is eligible for a 1099 form."
           },
-          "email": { "type": "string", "description": "Email address." },
-          "fax": { "type": "string", "description": "Fax number." },
+          "email": {
+            "type": "string",
+            "description": "Email address."
+          },
+          "fax": {
+            "type": "string",
+            "description": "Fax number."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -15621,7 +19649,10 @@
             "format": "int64",
             "description": "Markup account id"
           },
-          "name": { "type": "string", "description": "Name." },
+          "name": {
+            "type": "string",
+            "description": "Name."
+          },
           "nameOnCheck": {
             "type": "string",
             "description": "Name to be used on checks."
@@ -15635,10 +19666,22 @@
             "format": "int32",
             "description": "The number of days within payments are due."
           },
-          "paymentTerms": { "type": "string", "description": "Payment terms." },
-          "phone": { "type": "string", "description": "Phone number." },
-          "searchTag": { "type": "string", "description": "Search Tag" },
-          "state": { "type": "string", "description": "State." },
+          "paymentTerms": {
+            "type": "string",
+            "description": "Payment terms."
+          },
+          "phone": {
+            "type": "string",
+            "description": "Phone number."
+          },
+          "searchTag": {
+            "type": "string",
+            "description": "Search Tag"
+          },
+          "state": {
+            "type": "string",
+            "description": "State."
+          },
           "syncToVMM": {
             "type": "boolean",
             "example": false,
@@ -15648,14 +19691,26 @@
             "type": "string",
             "description": "Tax identification number."
           },
-          "taxPayerName": { "type": "string", "description": "Tax Payer Name" },
+          "taxPayerName": {
+            "type": "string",
+            "description": "Tax Payer Name"
+          },
           "timeTracking": {
             "type": "string",
             "description": "Time Tracking, is enabled or disabled"
           },
-          "type": { "type": "string", "description": "The type of vendor." },
-          "website": { "type": "string", "description": "Website URL." },
-          "zip": { "type": "string", "description": "ZIP or postal code." }
+          "type": {
+            "type": "string",
+            "description": "The type of vendor."
+          },
+          "website": {
+            "type": "string",
+            "description": "Website URL."
+          },
+          "zip": {
+            "type": "string",
+            "description": "ZIP or postal code."
+          }
         },
         "description": "Vendor"
       },
@@ -15677,7 +19732,10 @@
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "contactID": {
             "type": "integer",
             "format": "int64",
@@ -15715,7 +19773,8 @@
               "ECHECK",
               "NACHA",
               "RENTMONEY",
-              "PUBLIC_ASSISTANCE"
+              "PUBLIC_ASSISTANCE",
+              "PAYMENT_TYPE_NA"
             ]
           },
           "portfolioID": {
@@ -15723,13 +19782,18 @@
             "format": "int64",
             "description": "Id of the portfolio to apply the payment to."
           },
-          "refNo": { "type": "string", "description": "Reference No." }
+          "refNo": {
+            "type": "string",
+            "description": "Reference No."
+          }
         },
         "description": "Charge for request"
       },
       "SaveWorkOrderTask": {
         "type": "object",
-        "required": ["description"],
+        "required": [
+          "description"
+        ],
         "properties": {
           "completed": {
             "type": "boolean",
@@ -15833,7 +19897,10 @@
             "format": "date-time",
             "description": "Date and time the record was created. (Timezone: UTC)"
           },
-          "description": { "type": "string", "description": "Description." },
+          "description": {
+            "type": "string",
+            "description": "Description."
+          },
           "endDate": {
             "type": "string",
             "format": "date",
@@ -15847,7 +19914,13 @@
           "frequency": {
             "type": "string",
             "description": "Payment frequency.",
-            "enum": ["WEEKLY", "MONTHLY", "QUARTERLY", "SEMIANNUAL", "YEARLY"]
+            "enum": [
+              "WEEKLY",
+              "MONTHLY",
+              "QUARTERLY",
+              "SEMIANNUAL",
+              "YEARLY"
+            ]
           },
           "glAccountID": {
             "type": "integer",
@@ -15921,7 +19994,10 @@
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "contactID": {
             "type": "integer",
             "format": "int64",
@@ -15964,7 +20040,8 @@
               "ECHECK",
               "NACHA",
               "RENTMONEY",
-              "PUBLIC_ASSISTANCE"
+              "PUBLIC_ASSISTANCE",
+              "PAYMENT_TYPE_NA"
             ]
           },
           "refNo": {
@@ -15977,12 +20054,26 @@
       "LeaseStatus": {
         "type": "object",
         "properties": {
-          "defineActive": { "type": "boolean" },
-          "id": { "type": "integer", "format": "int64" },
-          "orderIndex": { "type": "integer", "format": "int32" },
-          "portalLoginEnabled": { "type": "boolean" },
-          "readonly": { "type": "boolean" },
-          "status": { "type": "string" }
+          "defineActive": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "orderIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "portalLoginEnabled": {
+            "type": "boolean"
+          },
+          "readonly": {
+            "type": "boolean"
+          },
+          "status": {
+            "type": "string"
+          }
         },
         "description": "Lease Status"
       },
@@ -15994,7 +20085,10 @@
             "format": "int32",
             "description": "Fee due day."
           },
-          "feeType": { "type": "string", "description": "Late fee type." },
+          "feeType": {
+            "type": "string",
+            "description": "Late fee type."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
@@ -16054,14 +20148,20 @@
       },
       "Payment": {
         "type": "object",
-        "required": ["amount", "date"],
+        "required": [
+          "amount",
+          "date"
+        ],
         "properties": {
           "amount": {
             "type": "number",
             "format": "double",
             "description": "Amount."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "contactID": {
             "type": "integer",
             "format": "int64",
@@ -16132,7 +20232,8 @@
               "ECHECK",
               "NACHA",
               "RENTMONEY",
-              "PUBLIC_ASSISTANCE"
+              "PUBLIC_ASSISTANCE",
+              "PAYMENT_TYPE_NA"
             ]
           },
           "portfolioID": {
@@ -16140,14 +20241,23 @@
             "format": "int64",
             "description": "Id of the portfolio associated with this transaction."
           },
-          "refNo": { "type": "string", "description": "Reference number." },
-          "status": { "type": "string", "description": "Lease status." }
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          },
+          "status": {
+            "type": "string",
+            "description": "Lease status."
+          }
         },
         "description": "Tenant Payment"
       },
       "ChargeTx": {
         "type": "object",
-        "required": ["amount", "date"],
+        "required": [
+          "amount",
+          "date"
+        ],
         "properties": {
           "amount": {
             "type": "number",
@@ -16164,7 +20274,10 @@
             "format": "double",
             "description": "The amount paid for the charge."
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "createdBy": {
             "type": "string",
             "description": "User who created the record."
@@ -16211,20 +20324,28 @@
           "payments": {
             "type": "array",
             "description": "List of payment charge history.",
-            "items": { "$ref": "#/components/schemas/PaymentCharge" }
+            "items": {
+              "$ref": "#/components/schemas/PaymentCharge"
+            }
           },
           "portfolioID": {
             "type": "integer",
             "format": "int64",
             "description": "Id of the portfolio associated with this charge."
           },
-          "refNo": { "type": "string", "description": "Reference number." }
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          }
         },
         "description": "Charge Transaction"
       },
       "SaveBankDeposit": {
         "type": "object",
-        "required": ["bankGLAccountID", "listOfTxIDs"],
+        "required": [
+          "bankGLAccountID",
+          "listOfTxIDs"
+        ],
         "properties": {
           "bankGLAccountID": {
             "type": "integer",
@@ -16286,7 +20407,10 @@
       },
       "SaveCheck": {
         "type": "object",
-        "required": ["checkDate", "destinationAccountID"],
+        "required": [
+          "checkDate",
+          "destinationAccountID"
+        ],
         "properties": {
           "checkDate": {
             "type": "string",
@@ -16296,15 +20420,23 @@
           "checkSplits": {
             "type": "array",
             "description": "Check Split list.",
-            "items": { "$ref": "#/components/schemas/SaveCheckSplit" }
+            "items": {
+              "$ref": "#/components/schemas/SaveCheckSplit"
+            }
           },
-          "comments": { "type": "string", "description": "Comments." },
+          "comments": {
+            "type": "string",
+            "description": "Comments."
+          },
           "destinationAccountID": {
             "type": "integer",
             "format": "int64",
             "description": "Destination AccountID."
           },
-          "refNo": { "type": "string", "description": "Check Ref No." },
+          "refNo": {
+            "type": "string",
+            "description": "Check Ref No."
+          },
           "toBePrinted": {
             "type": "boolean",
             "example": false,
@@ -16320,7 +20452,11 @@
       },
       "SaveBill": {
         "type": "object",
-        "required": ["billDate", "dueDate", "vendorID"],
+        "required": [
+          "billDate",
+          "dueDate",
+          "vendorID"
+        ],
         "properties": {
           "billDate": {
             "type": "string",
@@ -16335,9 +20471,14 @@
           "billSplits": {
             "type": "array",
             "description": "Splits list.",
-            "items": { "$ref": "#/components/schemas/SaveBillSplit" }
+            "items": {
+              "$ref": "#/components/schemas/SaveBillSplit"
+            }
           },
-          "comments": { "type": "string", "description": "Description." },
+          "comments": {
+            "type": "string",
+            "description": "Description."
+          },
           "dueDate": {
             "type": "string",
             "format": "date",
@@ -16363,8 +20504,14 @@
             "format": "date",
             "description": "Payment Date."
           },
-          "refNo": { "type": "string", "description": "Reference number." },
-          "terms": { "type": "string", "description": "Bill terms." },
+          "refNo": {
+            "type": "string",
+            "description": "Reference number."
+          },
+          "terms": {
+            "type": "string",
+            "description": "Bill terms."
+          },
           "vendorID": {
             "type": "integer",
             "format": "int64",
@@ -16380,18 +20527,35 @@
       },
       "SaveOwner": {
         "type": "object",
-        "required": ["firstName", "lastName"],
+        "required": [
+          "firstName",
+          "lastName"
+        ],
         "properties": {
-          "address": { "$ref": "#/components/schemas/SaveAddress" },
-          "email": { "type": "string", "description": "Owner EMail." },
-          "firstName": { "type": "string", "description": "Owner First Name." },
-          "homePhone": { "type": "string", "description": "Owner Home Phone." },
+          "address": {
+            "$ref": "#/components/schemas/SaveAddress"
+          },
+          "email": {
+            "type": "string",
+            "description": "Owner EMail."
+          },
+          "firstName": {
+            "type": "string",
+            "description": "Owner First Name."
+          },
+          "homePhone": {
+            "type": "string",
+            "description": "Owner Home Phone."
+          },
           "id": {
             "type": "integer",
             "format": "int64",
             "description": "Unique identifier."
           },
-          "lastName": { "type": "string", "description": "Owner Last Name." },
+          "lastName": {
+            "type": "string",
+            "description": "Owner Last Name."
+          },
           "mobilePhone": {
             "type": "string",
             "description": "Owner Mobile Phone."
@@ -16405,7 +20569,10 @@
             "format": "double",
             "description": "Ownership percentage."
           },
-          "workPhone": { "type": "string", "description": "Owner Work Phone." }
+          "workPhone": {
+            "type": "string",
+            "description": "Owner Work Phone."
+          }
         },
         "description": "Save Owner Contact"
       },
@@ -16420,7 +20587,9 @@
           "addendums": {
             "type": "array",
             "description": "Lease addendum(s).",
-            "items": { "$ref": "#/components/schemas/LeaseClause" }
+            "items": {
+              "$ref": "#/components/schemas/LeaseClause"
+            }
           },
           "baseRent": {
             "type": "number",
@@ -16439,7 +20608,9 @@
           "contacts": {
             "type": "array",
             "description": "List of the current tenants on the lease.",
-            "items": { "$ref": "#/components/schemas/LeaseContact" }
+            "items": {
+              "$ref": "#/components/schemas/LeaseContact"
+            }
           },
           "createdBy": {
             "type": "string",
@@ -16453,7 +20624,9 @@
           "customFields": {
             "type": "array",
             "description": "Custom fields.",
-            "items": { "$ref": "#/components/schemas/CustomField" }
+            "items": {
+              "$ref": "#/components/schemas/CustomField"
+            }
           },
           "endDate": {
             "type": "string",
@@ -16488,7 +20661,10 @@
             "format": "double",
             "description": "Lease Balance."
           },
-          "leaseName": { "type": "string", "description": "Lease Name." },
+          "leaseName": {
+            "type": "string",
+            "description": "Lease Name."
+          },
           "location": {
             "type": "string",
             "description": "Building and/or units the lease is currently attached to."
@@ -16530,7 +20706,10 @@
             "format": "date",
             "description": "Day that the tenant(s) are expected to vacate the property."
           },
-          "searchTag": { "type": "string", "description": "Search tag." },
+          "searchTag": {
+            "type": "string",
+            "description": "Search tag."
+          },
           "signedDate": {
             "type": "string",
             "format": "date",
@@ -16582,8 +20761,20 @@
     }
   },
   "security": [
-    { "clientId": [] },
-    { "clientSecret": [] },
-    { "organizationId": [] }
+    {
+      "clientId": [
+
+      ]
+    },
+    {
+      "clientSecret": [
+
+      ]
+    },
+    {
+      "organizationId": [
+
+      ]
+    }
   ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+# To run the container and rebuild the gem:
+# docker-compose run --rm app bash
+# > bin/rebuild.sh
+services:
+  app:
+    build: .
+    volumes:
+      - .:/app
+      - bundle_cache:/usr/local/bundle
+    command: /bin/bash
+    stdin_open: true
+    tty: true
+    environment:
+      - BUNDLE_PATH=/usr/local/bundle
+      - BUNDLE_APP_CONFIG=/usr/local/bundle
+
+volumes:
+  bundle_cache:  # Persists installed gems between container runs

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -9,7 +9,7 @@
 | **address** | [**Address**](Address.md) |  | [optional] |
 | **amenities** | [**Array&lt;Amenity&gt;**](Amenity.md) | Property amenities list. | [optional] |
 | **application_fee_rule** | **String** | Application fee rule | [optional] |
-| **area_units** | **String** | Property total area units. | [optional] |
+| **area_units** | **String** | Property total area units. | [optional][default to &#39;Sq Ft&#39;] |
 | **category** | **String** | Property category. | [optional] |
 | **count_unit** | **Integer** | Number of units in the building. | [optional] |
 | **county** | **String** | Property region of a state. | [optional] |

--- a/docs/Unit.md
+++ b/docs/Unit.md
@@ -8,7 +8,7 @@
 | **active** | **Boolean** | Indicates if the property is active or inactive. | [optional] |
 | **address** | [**Address**](Address.md) |  | [optional] |
 | **amenities** | [**Array&lt;Amenity&gt;**](Amenity.md) | Property amenities list. | [optional] |
-| **area_units** | **String** | Property total area units. | [optional] |
+| **area_units** | **String** | Property total area units. | [optional][default to &#39;Sq Ft&#39;] |
 | **building_id** | **Integer** | Id of the building associated with this unit. | [optional] |
 | **category** | **String** | Property category. | [optional] |
 | **county** | **String** | Property region of a state. | [optional] |

--- a/lib/propertyware/models/building.rb
+++ b/lib/propertyware/models/building.rb
@@ -347,6 +347,8 @@ module Propertyware
 
       if attributes.key?(:'area_units')
         self.area_units = attributes[:'area_units']
+      else
+        self.area_units = 'Sq Ft'
       end
 
       if attributes.key?(:'category')
@@ -558,8 +560,7 @@ module Propertyware
     def area_units=(area_units)
       validator = EnumAttributeValidator.new('String', ["Sq Ft", "Sq M"])
       unless validator.valid?(area_units)
-        # fail ArgumentError, "invalid value #{ area_units.inspect } for \"area_units\", must be one of #{validator.allowable_values}."
-        area_units = "Sq Ft"
+        area_units = 'Sq Ft'
       end
       @area_units = area_units
     end

--- a/lib/propertyware/models/check.rb
+++ b/lib/propertyware/models/check.rb
@@ -253,7 +253,7 @@ module Propertyware
       return false if @date.nil?
       return false if @destination_account_id.nil?
       return false if @payee_payer.nil?
-      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       return false unless payment_type_validator.valid?(@payment_type)
       true
     end
@@ -261,7 +261,7 @@ module Propertyware
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] payment_type Object to be assigned
     def payment_type=(payment_type)
-      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       unless validator.valid?(payment_type)
         fail ArgumentError, "invalid value #{ payment_type.inspect } for \"payment_type\", must be one of #{validator.allowable_values}."
       end

--- a/lib/propertyware/models/owner_contribution.rb
+++ b/lib/propertyware/models/owner_contribution.rb
@@ -223,7 +223,7 @@ module Propertyware
     def valid?
       return false if @amount.nil?
       return false if @date.nil?
-      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       return false unless payment_type_validator.valid?(@payment_type)
       true
     end
@@ -231,7 +231,7 @@ module Propertyware
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] payment_type Object to be assigned
     def payment_type=(payment_type)
-      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       unless validator.valid?(payment_type)
         fail ArgumentError, "invalid value #{ payment_type.inspect } for \"payment_type\", must be one of #{validator.allowable_values}."
       end

--- a/lib/propertyware/models/owner_draw.rb
+++ b/lib/propertyware/models/owner_draw.rb
@@ -223,7 +223,7 @@ module Propertyware
     def valid?
       return false if @amount.nil?
       return false if @date.nil?
-      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       return false unless payment_type_validator.valid?(@payment_type)
       true
     end
@@ -231,7 +231,7 @@ module Propertyware
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] payment_type Object to be assigned
     def payment_type=(payment_type)
-      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       unless validator.valid?(payment_type)
         fail ArgumentError, "invalid value #{ payment_type.inspect } for \"payment_type\", must be one of #{validator.allowable_values}."
       end

--- a/lib/propertyware/models/payment.rb
+++ b/lib/propertyware/models/payment.rb
@@ -250,7 +250,7 @@ module Propertyware
     def valid?
       return false if @amount.nil?
       return false if @date.nil?
-      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       return false unless payment_type_validator.valid?(@payment_type)
       true
     end
@@ -258,7 +258,7 @@ module Propertyware
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] payment_type Object to be assigned
     def payment_type=(payment_type)
-      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       unless validator.valid?(payment_type)
         fail ArgumentError, "invalid value #{ payment_type.inspect } for \"payment_type\", must be one of #{validator.allowable_values}."
       end

--- a/lib/propertyware/models/payment_charge.rb
+++ b/lib/propertyware/models/payment_charge.rb
@@ -191,7 +191,7 @@ module Propertyware
     def valid?
       return false if @amount.nil?
       return false if @date.nil?
-      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       return false unless payment_type_validator.valid?(@payment_type)
       return false if @settled_date.nil?
       true
@@ -200,7 +200,7 @@ module Propertyware
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] payment_type Object to be assigned
     def payment_type=(payment_type)
-      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       unless validator.valid?(payment_type)
         fail ArgumentError, "invalid value #{ payment_type.inspect } for \"payment_type\", must be one of #{validator.allowable_values}."
       end

--- a/lib/propertyware/models/save_owner_contribution.rb
+++ b/lib/propertyware/models/save_owner_contribution.rb
@@ -206,7 +206,7 @@ module Propertyware
       return false if @destination_account_id.nil?
       return false if @gl_account_id.nil?
       return false if @payment_type.nil?
-      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       return false unless payment_type_validator.valid?(@payment_type)
       return false if @portfolio_id.nil?
       return false if @ref_no.nil?
@@ -216,7 +216,7 @@ module Propertyware
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] payment_type Object to be assigned
     def payment_type=(payment_type)
-      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       unless validator.valid?(payment_type)
         fail ArgumentError, "invalid value #{ payment_type.inspect } for \"payment_type\", must be one of #{validator.allowable_values}."
       end

--- a/lib/propertyware/models/save_payment.rb
+++ b/lib/propertyware/models/save_payment.rb
@@ -207,7 +207,7 @@ module Propertyware
       return false if @destination_account_id.nil?
       return false if @lease_id.nil?
       return false if @payment_type.nil?
-      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      payment_type_validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       return false unless payment_type_validator.valid?(@payment_type)
       return false if @ref_no.nil?
       true
@@ -216,7 +216,7 @@ module Propertyware
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] payment_type Object to be assigned
     def payment_type=(payment_type)
-      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      validator = EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       unless validator.valid?(payment_type)
         fail ArgumentError, "invalid value #{ payment_type.inspect } for \"payment_type\", must be one of #{validator.allowable_values}."
       end

--- a/lib/propertyware/models/unit.rb
+++ b/lib/propertyware/models/unit.rb
@@ -293,6 +293,8 @@ module Propertyware
 
       if attributes.key?(:'area_units')
         self.area_units = attributes[:'area_units']
+      else
+        self.area_units = 'Sq Ft'
       end
 
       if attributes.key?(:'building_id')
@@ -466,8 +468,7 @@ module Propertyware
     def area_units=(area_units)
       validator = EnumAttributeValidator.new('String', ["Sq Ft", "Sq M"])
       unless validator.valid?(area_units)
-        # fail ArgumentError, "invalid value #{ area_units.inspect } for \"area_units\", must be one of #{validator.allowable_values}."
-        area_units = "Sq Ft"
+        area_units = 'Sq Ft'
       end
       @area_units = area_units
     end

--- a/lib/propertyware/version.rb
+++ b/lib/propertyware/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 6.6.0
 =end
 
 module Propertyware
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -94,7 +94,7 @@ describe Propertyware::Check do
   describe 'test attribute "payment_type"' do
     it 'should work' do
       # assertion here. ref: https://rspec.info/features/3-12/rspec-expectations/built-in-matchers/
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       # validator.allowable_values.each do |value|
       #   expect { instance.payment_type = value }.not_to raise_error
       # end

--- a/spec/models/owner_contribution_spec.rb
+++ b/spec/models/owner_contribution_spec.rb
@@ -94,7 +94,7 @@ describe Propertyware::OwnerContribution do
   describe 'test attribute "payment_type"' do
     it 'should work' do
       # assertion here. ref: https://rspec.info/features/3-12/rspec-expectations/built-in-matchers/
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       # validator.allowable_values.each do |value|
       #   expect { instance.payment_type = value }.not_to raise_error
       # end

--- a/spec/models/owner_draw_spec.rb
+++ b/spec/models/owner_draw_spec.rb
@@ -94,7 +94,7 @@ describe Propertyware::OwnerDraw do
   describe 'test attribute "payment_type"' do
     it 'should work' do
       # assertion here. ref: https://rspec.info/features/3-12/rspec-expectations/built-in-matchers/
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       # validator.allowable_values.each do |value|
       #   expect { instance.payment_type = value }.not_to raise_error
       # end

--- a/spec/models/payment_charge_spec.rb
+++ b/spec/models/payment_charge_spec.rb
@@ -58,7 +58,7 @@ describe Propertyware::PaymentCharge do
   describe 'test attribute "payment_type"' do
     it 'should work' do
       # assertion here. ref: https://rspec.info/features/3-12/rspec-expectations/built-in-matchers/
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       # validator.allowable_values.each do |value|
       #   expect { instance.payment_type = value }.not_to raise_error
       # end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -106,7 +106,7 @@ describe Propertyware::Payment do
   describe 'test attribute "payment_type"' do
     it 'should work' do
       # assertion here. ref: https://rspec.info/features/3-12/rspec-expectations/built-in-matchers/
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       # validator.allowable_values.each do |value|
       #   expect { instance.payment_type = value }.not_to raise_error
       # end

--- a/spec/models/save_owner_contribution_spec.rb
+++ b/spec/models/save_owner_contribution_spec.rb
@@ -64,7 +64,7 @@ describe Propertyware::SaveOwnerContribution do
   describe 'test attribute "payment_type"' do
     it 'should work' do
       # assertion here. ref: https://rspec.info/features/3-12/rspec-expectations/built-in-matchers/
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       # validator.allowable_values.each do |value|
       #   expect { instance.payment_type = value }.not_to raise_error
       # end

--- a/spec/models/save_payment_spec.rb
+++ b/spec/models/save_payment_spec.rb
@@ -70,7 +70,7 @@ describe Propertyware::SavePayment do
   describe 'test attribute "payment_type"' do
     it 'should work' do
       # assertion here. ref: https://rspec.info/features/3-12/rspec-expectations/built-in-matchers/
-      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE"])
+      # validator = Petstore::EnumTest::EnumAttributeValidator.new('String', ["CHECK", "CHECK21", "CASHIERS_CHECK", "CREDIT_CARD", "CASH", "MONEY_ORDER", "OTHER", "CLICKPAY", "SECTION8", "EPAY", "ECHECK", "NACHA", "RENTMONEY", "PUBLIC_ASSISTANCE", "PAYMENT_TYPE_NA"])
       # validator.allowable_values.each do |value|
       #   expect { instance.payment_type = value }.not_to raise_error
       # end


### PR DESCRIPTION
The main change here is to add a new payment type to the propertyware json, using the fix_json.rb file.

**Other changes**

- The changes made in 1.3.1 weren't permanent because they weren't applied to the mustache template. To make this work, I had to first insert a default value in fix_json.rb, then the template has a condition to use that value instead of failing with an error. It works nicely.
- Added a docker config for installing dependencies and rebuilding the gem. Easier for me, possibly others.